### PR TITLE
Set limits on database queries

### DIFF
--- a/api/stats.py
+++ b/api/stats.py
@@ -6,15 +6,18 @@ import operator
 from db import Payload
 
 logger = logging.getLogger(settings.APP_NAME)
-
+LIMIT = 50000
 
 async def search(*args, **kwargs):
     logger.debug(f"Stats.search({args}, {kwargs})")
     stat_funcs = {'SuccessRate': _success_rate}
     func = stat_funcs[kwargs['stat']]
     func_params = {}
+    result = {}
+    offset = 0
 
-    payload_query = Payload.query
+    payload_query = Payload.query.limit(LIMIT)
+    payloads_count = await Payload.query.alias().count().gino.scalar()
 
     # Only get the past 24 hours for right now
     # Trying to calculate this against the whole database is too much
@@ -23,24 +26,26 @@ async def search(*args, **kwargs):
         operator.ge(Payload.date, twenty_four_hours)
     )
 
-    payloads = await payload_query.gino.all()
-    payloads_dump = [payload.dump() for payload in payloads]
-    func_params['payload'] = payloads_dump
-    if payloads is None:
-        return responses.not_found()
-    else:
-        return responses.get(func(func_params))
+    while offset < payloads_count:
+        payloads = await payload_query.offset(offset).gino.all()
+        payloads_dump = [payload.dump() for payload in payloads]
+        func_params['payload'] = payloads_dump
+        if payloads is None:
+            return responses.not_found()
+        result = await func(func_params, result)
+        offset += LIMIT
 
+    return responses.get(result)
 
-def _success_rate(params):
+async def _success_rate(params, result):
     payloads = params['payload']
-    services_dict = {}
     for payload in payloads:
-        if payload['service'] not in services_dict:
-            services_dict[payload['service']] = {'success': 0, 'failure': 0,
+        if payload['service'] not in result:
+            result[payload['service']] = {'success': 0, 'failure': 0,
                                                  'successPercent': 0, 'failPercent': 0}
         if payload['status'] == 'success' or payload['status'] == 'successful':
-            services_dict[payload['service']]['success'] += 1
+            result[payload['service']]['success'] += 1
         elif payload['status'] == 'error':
-            services_dict[payload['service']]['failure'] += 1
-    return services_dict
+            result[payload['service']]['failure'] += 1
+    return result
+


### PR DESCRIPTION
This will set limits for the number of payloads returned on each database call and does return stats, but right now it is still _slow_.