### PR TITLE
[RFR] Update sequences after bulk insert

### DIFF
--- a/manual_tests/mock_add_key.py
+++ b/manual_tests/mock_add_key.py
@@ -1,0 +1,40 @@
+import os
+import json
+import datetime
+import time
+import uuid
+from confluent_kafka import Producer
+
+
+request_id = str(uuid.uuid1())
+inventory_id = str(uuid.uuid1())
+system_id = str(uuid.uuid1())
+payload = {
+    'service': 'this_service_is_new',
+    'request_id': request_id,
+    'status': 'received',
+    'inventory_id': inventory_id,
+    'system_id': system_id,
+    'source': 'this_source_is_new'
+}
+
+
+def produceMessageCallback(err, msg):
+    print('Produce message callback err: %s' % (err))
+    print('Produce message callback msg: %s' % (msg))
+    """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+    if err is not None:
+        print('Message delivery failed: {}'.format(err))
+    else:
+        print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
+print("Posting payload status")
+p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')})
+payload['date'] = str(datetime.datetime.now())
+p.poll(0)
+p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
+        json.dumps(payload), callback=produceMessageCallback)
+p.flush()
+time.sleep(1)

--- a/migrations/dee7867868f7_update_sequences.py
+++ b/migrations/dee7867868f7_update_sequences.py
@@ -1,0 +1,26 @@
+"""update sequences
+
+Revision ID: dee7867868f7
+Revises: 85cddc32f5d2
+Create Date: 2020-08-03 11:26:01.136424
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dee7867868f7'
+down_revision = '85cddc32f5d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('SELECT setval(\'services_id_seq\',(SELECT GREATEST(MAX(id)+1,nextval(\'services_id_seq\'))-1 FROM services));')
+    op.execute('SELECT setval(\'sources_id_seq\',(SELECT GREATEST(MAX(id)+1,nextval(\'sources_id_seq\'))-1 FROM sources));')
+
+
+def downgrade():
+    op.execute('ALTER SEQUENCE services_id_seq RESTART WITH 1;')
+    op.execute('ALTER SEQUENCE sources_id_seq RESTART WITH 1;')


### PR DESCRIPTION
This PR fixes https://projects.engineering.redhat.com/browse/RHCLOUD-8304

It fixes the issue we we're seeing by resetting the start point in the sequences for `services_id_seq` and `sources_id_seq`.