### PR TITLE
Ensure incoming data is of type string

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ accumulated_durations = {}
 
 async def clean_durations():
     threshold = timedelta(os.environ.get('DURATIONS_DELETION_THRESHOLD', 60))
-    interval = timdelta(os.environ.get('DURATIONS_DELETION_INTERVAL', 20))
+    interval = int(os.environ.get('DURATIONS_DELETION_INTERVAL', 20))
     while True:
         await asyncio.sleep(interval, loop=loop)
         ids_to_delete = []
@@ -304,6 +304,10 @@ async def process_payload_status(json_msgs):
 
         if data:
             logger.info("Payload message processed as JSON.")
+
+            # ensure data is of type string
+            for key in data:
+                data[key] = str(data[key])
 
             # Check for missing keys
             expected_keys = ["service", "request_id", "status", "date"]


### PR DESCRIPTION
This should resolve the following error (and a small mistake in the duration sockets)

```
ERROR [payload-tracker-service.process_payload_status:364] [139962304427840  MainThread] [1] Failed to parse message with Error: Traceback (most recent call last):
  File "asyncpg/protocol/prepared_stmt.pyx", line 146, in asyncpg.protocol.protocol.PreparedStatementState._encode_bind_msg
  File "asyncpg/protocol/codecs/base.pyx", line 192, in asyncpg.protocol.protocol.Codec.encode
  File "asyncpg/protocol/codecs/base.pyx", line 103, in asyncpg.protocol.protocol.Codec.encode_scalar
  File "asyncpg/pgproto/./codecs/text.pyx", line 29, in asyncpg.pgproto.pgproto.text_encode
  File "asyncpg/pgproto/./codecs/text.pyx", line 12, in asyncpg.pgproto.pgproto.as_pg_string_and_size
TypeError: expected str, got int
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "app.py", line 336, in process_payload_status
    payload_dump = await get_payload()
  File "app.py", line 332, in get_payload
    payload = await Payload.query.where(Payload.request_id == data['request_id']).gino.all()
  File "/opt/app-root/lib/python3.6/site-packages/gino/api.py", line 127, in all
    return await self._query.bind.all(self._query, *multiparams, **params)
  File "/opt/app-root/lib/python3.6/site-packages/gino/engine.py", line 740, in all
    return await conn.all(clause, *multiparams, **params)
  File "/opt/app-root/lib/python3.6/site-packages/gino/engine.py", line 316, in all
    return await result.execute()
  File "/opt/app-root/lib/python3.6/site-packages/gino/dialects/base.py", line 215, in execute
    context.statement, context.timeout, args, 1 if one else 0
  File "/opt/app-root/lib/python3.6/site-packages/gino/dialects/asyncpg.py", line 184, in async_execute
    result, stmt = await getattr(conn, "_do_execute")(query, executor, timeout)
  File "/opt/app-root/lib/python3.6/site-packages/asyncpg/connection.py", line 1476, in _do_execute
    result = await executor(stmt, None)
  File "asyncpg/protocol/protocol.pyx", line 178, in bind_execute
  File "asyncpg/protocol/prepared_stmt.pyx", line 160, in asyncpg.protocol.protocol.PreparedStatementState._encode_bind_msg
asyncpg.exceptions.DataError: invalid input for query argument $1: -1 (expected str, got int)
```