### PR TITLE
Use timestamp with timezone

### DIFF
--- a/api/payloads.py
+++ b/api/payloads.py
@@ -4,6 +4,7 @@ from cache import cache
 from sqlalchemy import inspect, cast, TIMESTAMP
 from sqlalchemy.orm import Bundle
 from dateutil import parser
+from dateutil.tz import tzutc
 import responses
 import operator
 import logging
@@ -42,10 +43,10 @@ async def search(*args, **kwargs):
         for date_field in ['created_at']:
             for date_group_str, date_group_fn in date_group_fns.items():
                 if date_field + date_group_str in kwargs:
-                    the_date = parser.parse(kwargs[date_field + date_group_str])
+                    the_date = parser.parse(kwargs[date_field + date_group_str]).astimezone(tzutc())
                     payload_query.append_whereclause(
                         date_group_fn(
-                            cast(getattr(Payload, date_field), TIMESTAMP), the_date.replace(tzinfo=None)))
+                            cast(getattr(Payload, date_field), TIMESTAMP(timezone=tzutc())), the_date))
 
         # Get the count before we apply the page size and offset
         payloads_count = await conn.scalar(payload_query.alias().count())

--- a/api/statuses.py
+++ b/api/statuses.py
@@ -4,6 +4,7 @@ from cache import cache
 from sqlalchemy import inspect, cast, TIMESTAMP
 from sqlalchemy.orm import Bundle
 from dateutil import parser
+from dateutil.tz import tzutc
 import responses
 import operator
 import logging
@@ -64,11 +65,11 @@ async def search(*args, **kwargs):
         for date_field in ['date', 'created_at']:
             for date_group_str, date_group_fn in date_group_fns.items():
                 if date_field + date_group_str in kwargs:
-                    the_date = parser.parse(kwargs[date_field + date_group_str])
+                    the_date = parser.parse(kwargs[date_field + date_group_str]).astimezone(tzutc())
                     for query in [statuses_query, statuses_count]:
                         query.append_whereclause(
                             date_group_fn(
-                                cast(getattr(status_table, date_field), TIMESTAMP), the_date.replace(tzinfo=None)))
+                                cast(getattr(status_table, date_field), TIMESTAMP(timezone=tzutc())), the_date))
 
         # Then apply page size and offset
         sort_func = getattr(db, kwargs['sort_dir'])

--- a/manual_tests/mock_add_key.py
+++ b/manual_tests/mock_add_key.py
@@ -32,7 +32,7 @@ def produceMessageCallback(err, msg):
 
 print("Posting payload status")
 p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')})
-payload['date'] = str(datetime.datetime.now())
+payload['date'] = str(datetime.datetime.utcnow())
 p.poll(0)
 p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
         json.dumps(payload), callback=produceMessageCallback)

--- a/manual_tests/mock_loadtest.py
+++ b/manual_tests/mock_loadtest.py
@@ -104,7 +104,7 @@ p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhos
 for x in range(100):  # increase this for more messages
     payloads = generatePayloads()
     for payload in payloads:
-        payload['date'] = str(datetime.datetime.now())
+        payload['date'] = str(datetime.datetime.utcnow())
         p.poll(0)
         p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
                     json.dumps(payload), callback=produceMessageCallback)

--- a/manual_tests/mock_payload.py
+++ b/manual_tests/mock_payload.py
@@ -82,7 +82,7 @@ payloads = [
 print(f'Posting payload status with request_id: {request_id}')
 p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')})
 for payload in payloads:
-  payload['date'] = str(datetime.datetime.now())
+  payload['date'] = str(datetime.datetime.utcnow())
   p.poll(0)
   p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
             json.dumps(payload), callback=produceMessageCallback)

--- a/manual_tests/mock_prod_env.py
+++ b/manual_tests/mock_prod_env.py
@@ -58,7 +58,7 @@ async def post_payload():
             print(f'Posting payload status with request_id: {request_id}')
             payload = { 'request_id' : request_id, 'service': service, 'status': statues_dict[status] }
             p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')})
-            payload['date'] = str(datetime.datetime.now())
+            payload['date'] = str(datetime.datetime.utcnow())
             p.poll(0)
             p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
                     json.dumps(payload), callback=produceMessageCallback)


### PR DESCRIPTION
This fixes a bug involving using `TIMESTAMP WITHOUT TIME ZONE` instead of `TIMESTAMP WITH TIME ZONE` to sort entries by date.

**Before:**

```
lmccann@MacBook-Pro payload-tracker % time curl -I -X GET 'http://localhost:8080/v1/statuses?date_lte=2020-09-16T23:14:18.789924Z&date_gt=2020-09-16T23:14:18.708708Z'
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 802
Date: Wed, 16 Sep 2020 19:39:53 GMT
Server: Python/3.6 aiohttp/3.6.2

curl -I -X GET   0.01s user 0.01s system 0% cpu 1:26.19 total
```

**After:**

```
lmccann@MacBook-Pro payload-tracker % time curl -I -X GET 'http://localhost:8080/v1/statuses?date_lte=2020-09-16T23:14:18.789924Z&date_gt=2020-09-16T23:14:18.708708Z'
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 804
Date: Wed, 16 Sep 2020 19:38:06 GMT
Server: Python/3.6 aiohttp/3.6.2

curl -I -X GET   0.00s user 0.01s system 29% cpu 0.053 total
```