### PR TITLE
Replace payload_statuses with partitioned_statuses

### DIFF
--- a/db.py
+++ b/db.py
@@ -45,22 +45,6 @@ class PayloadStatus(db.Model):
         return {k: v for k, v in self.__values__.items() if v is not None}
 
 
-class PartitionedStatus(db.Model):
-    __tablename__ = 'partitioned_statuses'
-
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    payload_id = db.Column(db.Integer, db.ForeignKey('payloads.id', ondelete='CASCADE'))
-    service_id = db.Column(db.Integer, db.ForeignKey('services.id'))
-    source_id = db.Column(db.Integer, db.ForeignKey('sources.id'))
-    status_id = db.Column(db.Unicode, db.ForeignKey('statuses.id'))
-    status_msg = db.Column(db.Unicode)
-    date = db.Column(db.DateTime(timezone=True), server_default="timezone('utc'::text, now())")
-    created_at = db.Column(db.DateTime(timezone=True), server_default="timezone('utc'::text, now())")
-
-    def dump(self):
-        return {k: v for k, v in self.__values__.items() if v is not None}
-
-
 class Sources(db.Model):
     __tablename__ = 'sources'
 

--- a/migrations/e6fb7331772d_substitute_partitions_for_payload_.py
+++ b/migrations/e6fb7331772d_substitute_partitions_for_payload_.py
@@ -1,0 +1,133 @@
+"""Substitute partitions for payload_statuses
+
+Revision ID: e6fb7331772d
+Revises: 867aaf69aeba
+Create Date: 2020-10-01 11:02:52.302126
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e6fb7331772d'
+down_revision = '867aaf69aeba'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('DROP FUNCTION IF EXISTS update_partition() CASCADE;')
+    op.execute('DROP FUNCTION IF EXISTS create_partition(START TIMESTAMPTZ, STOP TIMESTAMPTZ);')
+    op.execute('DROP TABLE payload_statuses CASCADE;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME TO payload_statuses;')
+
+    op.execute('ALTER TABLE payload_statuses RENAME CONSTRAINT partitioned_statuses_pk TO payload_statuses_pkey;')
+    op.execute('ALTER TABLE payload_statuses RENAME CONSTRAINT partitioned_statuses_payload_id_fkey TO payload_statuses_payload_id_fkey;')
+    op.execute('ALTER TABLE payload_statuses RENAME CONSTRAINT partitioned_statuses_service_id_fkey TO payload_statuses_service_id_fkey;')
+    op.execute('ALTER TABLE payload_statuses RENAME CONSTRAINT partitioned_statuses_source_id_fkey TO payload_statuses_source_id_fkey;')
+    op.execute('ALTER TABLE payload_statuses RENAME CONSTRAINT partitioned_statuses_status_id_fkey TO payload_statuses_status_id_fkey;')
+    op.execute('ALTER SEQUENCE partitioned_statuses_id_seq RENAME TO payload_statuses_id_seq;')
+
+    op.execute('''
+        CREATE OR REPLACE FUNCTION create_partition(START TIMESTAMPTZ, STOP TIMESTAMPTZ) RETURNS VOID LANGUAGE PLPGSQL AS $$
+            DECLARE
+                start TEXT := get_date_string(START);
+                stop TEXT := get_date_string(STOP);
+                partition VARCHAR := FORMAT('partition_%s_%s', start, stop);
+            BEGIN
+                EXECUTE 'CREATE TABLE IF NOT EXISTS ' || partition || ' PARTITION OF payload_statuses FOR VALUES FROM (' || quote_literal(START) || ') TO (' || quote_literal(STOP) || ');';
+                EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS ' || partition || '_id_idx ON ' || partition || ' USING btree(id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_payload_id_idx ON ' || partition || ' USING btree(payload_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_service_id_idx ON ' || partition || ' USING btree(service_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_source_id_idx ON ' || partition || ' USING btree(source_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_status_id_idx ON ' || partition || ' USING btree(status_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_date_idx ON ' || partition || ' USING btree(date);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_created_at_idx ON ' || partition || ' USING btree(created_at);';
+            END;
+        $$;
+    ''')
+
+
+def downgrade():
+    op.execute('ALTER TABLE payload_statuses RENAME TO partitioned_statuses;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME CONSTRAINT payload_statuses_pkey TO partitioned_statuses_pk;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME CONSTRAINT payload_statuses_payload_id_fkey TO partitioned_statuses_payload_id_fkey;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME CONSTRAINT payload_statuses_service_id_fkey TO partitioned_statuses_service_id_fkey;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME CONSTRAINT payload_statuses_source_id_fkey TO partitioned_statuses_source_id_fkey;')
+    op.execute('ALTER TABLE partitioned_statuses RENAME CONSTRAINT payload_statuses_status_id_fkey TO partitioned_statuses_status_id_fkey;')
+    op.execute('ALTER SEQUENCE payload_statuses_id_seq RENAME TO partitioned_statuses_id_seq;')
+    op.create_table(
+        'payload_statuses',
+        sa.Column('id', sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column('payload_id', sa.Integer(), nullable=False),
+        sa.Column('service_id', sa.Integer(), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=True),
+        sa.Column('status_id', sa.Integer(), nullable=False),
+        sa.Column('status_msg', sa.String(), nullable=True),
+        sa.Column('date', sa.DateTime(timezone=True), server_default=sa.text("timezone('utc'::text, now())"), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text("timezone('utc'::text, now())"), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['payload_id'], ['payloads.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id']),
+        sa.ForeignKeyConstraint(['source_id'], ['sources.id']),
+        sa.ForeignKeyConstraint(['status_id'], ['sources.id'])
+    )
+
+    op.create_index('payload_statuses_id_idx', 'payload_statuses', ['id'], unique=True)
+    op.create_index('payload_statuses_payload_id_idx', 'payload_statuses', ['payload_id'], unique=False)
+    op.create_index('payload_statuses_service_id_idx', 'payload_statuses', ['service_id'], unique=False)
+    op.create_index('payload_statuses_source_id_idx', 'payload_statuses', ['source_id'], unique=False)
+    op.create_index('payload_statuses_status_id_idx', 'payload_statuses', ['status_id'], unique=False)
+    op.create_index('payload_statuses_status_msg_idx', 'payload_statuses', ['status_msg'], unique=False)
+    op.create_index('payload_statuses_date_idx', 'payload_statuses', ['date'], unique=False)
+    op.create_index('payload_statuses_created_at_idx', 'payload_statuses', ['created_at'], unique=False)
+
+    op.execute('DROP FUNCTION IF EXISTS create_partition(START TIMESTAMPTZ, STOP TIMESTAMPTZ);')
+    op.execute('''
+        CREATE OR REPLACE FUNCTION create_partition(START TIMESTAMPTZ, STOP TIMESTAMPTZ) RETURNS VOID LANGUAGE PLPGSQL AS $$
+            DECLARE
+                start TEXT := get_date_string(START);
+                stop TEXT := get_date_string(STOP);
+                partition VARCHAR := FORMAT('partition_%s_%s', start, stop);
+            BEGIN
+                EXECUTE 'CREATE TABLE IF NOT EXISTS ' || partition || ' PARTITION OF partitioned_statuses FOR VALUES FROM (' || quote_literal(START) || ') TO (' || quote_literal(STOP) || ');';
+                EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS ' || partition || '_id_idx ON ' || partition || ' USING btree(id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_payload_id_idx ON ' || partition || ' USING btree(payload_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_service_id_idx ON ' || partition || ' USING btree(service_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_source_id_idx ON ' || partition || ' USING btree(source_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_status_id_idx ON ' || partition || ' USING btree(status_id);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_date_idx ON ' || partition || ' USING btree(date);';
+                EXECUTE 'CREATE INDEX IF NOT EXISTS ' || partition || '_created_at_idx ON ' || partition || ' USING btree(created_at);';
+            END;
+        $$;
+    ''')
+
+    op.execute('''
+        CREATE OR REPLACE FUNCTION update_partition() RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+        BEGIN
+            INSERT INTO partitioned_statuses (
+                payload_id, service_id, source_id, status_id, status_msg, date, created_at
+            ) VALUES (
+                NEW.payload_id, NEW.service_id, NEW.source_id, NEW.status_id, NEW.status_msg, NEW.date, NEW.created_at
+            );
+            RETURN NEW;
+        EXCEPTION
+            WHEN check_violation THEN
+                PERFORM create_partition(NEW.date::DATE, NEW.date::DATE + INTERVAL \'1 DAY\');
+                INSERT INTO partitioned_statuses (
+                    payload_id, service_id, source_id, status_id, status_msg, date, created_at
+                ) VALUES (
+                    NEW.payload_id, NEW.service_id, NEW.source_id, NEW.status_id, NEW.status_msg, NEW.date, NEW.created_at
+                );
+                RETURN NEW;
+        END;
+        $$;
+    ''')
+
+    op.execute('''
+        CREATE TRIGGER update_partitions
+        BEFORE INSERT on payload_statuses
+        FOR EACH ROW
+        EXECUTE PROCEDURE update_partition();
+    ''')

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -145,12 +145,6 @@ paths:
     get:
       description: 'Get individual payload statuses for payloads.'
       parameters:
-        - name: partition
-          in: query
-          description: Tells api to query partitioned version of statuses table
-          required: false
-          type: boolean
-          default: false
         - name: page
           in: query
           description: A page number within the paginated result set.


### PR DESCRIPTION
This PR replaces the `payload_statuses` table for its partitioned equivalent `partitioned_statuses`. I have also updated the retry logic for inserting payload statuses into the database. We do the following on error:
1. Attempt to create new partition for the date range inclusive of the payload
2. Attempt reinsertion upon further error.

There is potentially a _cleaner_ way to implement this (by catching the asyncpg errors and assigning retry logic through on multiple `except` clauses), but I'm not sure if gino will give us back those error types.

Here's what the schemas look like:
```
Partitioned table "public.payload_statuses"
   Column   |           Type           | Collation | Nullable |                   Default                    | Storage  | Stats target | Description 
------------+--------------------------+-----------+----------+----------------------------------------------+----------+--------------+-------------
 id         | integer                  |           | not null | nextval('payload_statuses_id_seq'::regclass) | plain    |              | 
 payload_id | integer                  |           | not null |                                              | plain    |              | 
 service_id | integer                  |           | not null |                                              | plain    |              | 
 source_id  | integer                  |           |          |                                              | plain    |              | 
 status_id  | integer                  |           | not null |                                              | plain    |              | 
 status_msg | character varying        |           |          |                                              | extended |              | 
 date       | timestamp with time zone |           | not null | timezone('utc'::text, now())                 | plain    |              | 
 created_at | timestamp with time zone |           | not null | timezone('utc'::text, now())                 | plain    |              | 
Partition key: RANGE (date)
Indexes:
    "payload_statuses_pkey" PRIMARY KEY, btree (id, date)
Foreign-key constraints:
    "payload_statuses_payload_id_fkey" FOREIGN KEY (payload_id) REFERENCES payloads(id) ON DELETE CASCADE
    "payload_statuses_service_id_fkey" FOREIGN KEY (service_id) REFERENCES services(id)
    "payload_statuses_source_id_fkey" FOREIGN KEY (source_id) REFERENCES sources(id)
    "payload_statuses_status_id_fkey" FOREIGN KEY (status_id) REFERENCES statuses(id)
Partitions: partition_20200925_20200926 FOR VALUES FROM ('2020-09-25 00:00:00+00') TO ('2020-09-26 00:00:00+00'),
            partition_20200926_20200927 FOR VALUES FROM ('2020-09-26 00:00:00+00') TO ('2020-09-27 00:00:00+00'),
            partition_20200927_20200928 FOR VALUES FROM ('2020-09-27 00:00:00+00') TO ('2020-09-28 00:00:00+00'),
            partition_20200928_20200929 FOR VALUES FROM ('2020-09-28 00:00:00+00') TO ('2020-09-29 00:00:00+00'),
            partition_20200929_20200930 FOR VALUES FROM ('2020-09-29 00:00:00+00') TO ('2020-09-30 00:00:00+00'),
            partition_20200930_20201001 FOR VALUES FROM ('2020-09-30 00:00:00+00') TO ('2020-10-01 00:00:00+00'),
            partition_20201001_20201002 FOR VALUES FROM ('2020-10-01 00:00:00+00') TO ('2020-10-02 00:00:00+00'),
            partition_20201002_20201003 FOR VALUES FROM ('2020-10-02 00:00:00+00') TO ('2020-10-03 00:00:00+00')
```
```
Table "public.partition_20201001_20201002"
   Column   |           Type           | Collation | Nullable |                   Default                    | Storage  | Stats target | Description 
------------+--------------------------+-----------+----------+----------------------------------------------+----------+--------------+-------------
 id         | integer                  |           | not null | nextval('payload_statuses_id_seq'::regclass) | plain    |              | 
 payload_id | integer                  |           | not null |                                              | plain    |              | 
 service_id | integer                  |           | not null |                                              | plain    |              | 
 source_id  | integer                  |           |          |                                              | plain    |              | 
 status_id  | integer                  |           | not null |                                              | plain    |              | 
 status_msg | character varying        |           |          |                                              | extended |              | 
 date       | timestamp with time zone |           | not null | timezone('utc'::text, now())                 | plain    |              | 
 created_at | timestamp with time zone |           | not null | timezone('utc'::text, now())                 | plain    |              | 
Partition of: payload_statuses FOR VALUES FROM ('2020-10-01 00:00:00+00') TO ('2020-10-02 00:00:00+00')
Partition constraint: ((date IS NOT NULL) AND (date >= '2020-10-01 00:00:00+00'::timestamp with time zone) AND (date < '2020-10-02 00:00:00+00'::timestamp with time zone))
Indexes:
    "partition_20201001_20201002_pkey" PRIMARY KEY, btree (id, date)
    "partition_20201001_20201002_id_idx" UNIQUE, btree (id)
    "partition_20201001_20201002_created_at_idx" btree (created_at)
    "partition_20201001_20201002_date_idx" btree (date)
    "partition_20201001_20201002_payload_id_idx" btree (payload_id)
    "partition_20201001_20201002_service_id_idx" btree (service_id)
    "partition_20201001_20201002_source_id_idx" btree (source_id)
    "partition_20201001_20201002_status_id_idx" btree (status_id)
Foreign-key constraints:
    TABLE "payload_statuses" CONSTRAINT "payload_statuses_payload_id_fkey" FOREIGN KEY (payload_id) REFERENCES payloads(id) ON DELETE CASCADE
    TABLE "payload_statuses" CONSTRAINT "payload_statuses_service_id_fkey" FOREIGN KEY (service_id) REFERENCES services(id)
    TABLE "payload_statuses" CONSTRAINT "payload_statuses_source_id_fkey" FOREIGN KEY (source_id) REFERENCES sources(id)
    TABLE "payload_statuses" CONSTRAINT "payload_statuses_status_id_fkey" FOREIGN KEY (status_id) REFERENCES statuses(id)
Access method: heap
```