### PR TITLE
Update Prometheus metrics and unify with Sockets

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,2 +1,31 @@
 def dump(cols, res):
     return [{k.key: v for k, v in zip(cols, row) if v is not None} for row in res]
+
+# define class which uses tuple as key in key/value store
+class Triple():
+
+    def __init__(self, a, b, c):
+        self.key = (a, b)
+        self.value = c
+
+    def __repr__(self):
+        return f'{self.key}: {self.value}'
+
+# define a functional list of Triple objects
+class TripleSet():
+
+    def __init__(self, initialVal=None):
+        self.data = [initialVal] if initialVal and type(initialVal) is Triple else []
+
+    def keys(self):
+        return [item.key for item in self.data]
+
+    def values(self):
+        return [item.value for item in self.data]
+
+    def append(self, value):
+        if type(value) is Triple:
+            self.data.append(value)
+
+    def __repr__(self):
+        return repr(self.data)


### PR DESCRIPTION
This creates a single data structure in memory for servicing both the sockets and Prometheus metrics. The metrics and socket computations are now done in a single function which is called every time a new payload is processed. The cleaning function now works for both the sockets and metrics since we are using a single structure to maintain statuses in memory.