### PR TITLE
Update calculations for durations and prometheus metrics

### DIFF
--- a/dashboards/grafana-dashboard-clouddot-insights-payload-tracker-configmap.yaml
+++ b/dashboards/grafana-dashboard-clouddot-insights-payload-tracker-configmap.yaml
@@ -203,8 +203,8 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "sum(increase(payload_tracker_service_status_counter_total[1m])) by (service_name, status)",
-                "legendFormat": "{{service_name}} - {{status}}",
+                "expr": "sum(increase(payload_tracker_service_status_counter_total[1m])) by (service_name, status, source_name)",
+                "legendFormat": "{{service_name}} (source: {{source_name}}) - {{status}}",
                 "refId": "A"
               }
             ],
@@ -297,8 +297,8 @@ data:
                 "refId": "A"
               },
               {
-                "expr": "sum(rate(payload_tracker_upload_time_by_service_elapsed_sum[1m]) / rate(payload_tracker_upload_time_by_service_elapsed_count[1m])) by (service_name)",
-                "legendFormat": "{{service_name}}",
+                "expr": "sum(rate(payload_tracker_upload_time_by_service_elapsed_sum[1m]) / rate(payload_tracker_upload_time_by_service_elapsed_count[1m])) by (service_name, source_name)",
+                "legendFormat": "{{service_name}} (source: {{source_name}})",
                 "refId": "B"
               }
             ],

--- a/manual_tests/mock_payload.py
+++ b/manual_tests/mock_payload.py
@@ -36,7 +36,7 @@ payloads = [
 {
        'service': 'advisor-pup',
        'request_id': request_id,
-       'status': 'processing'
+       'status': 'received'
 },
 {
        'service': 'advisor-pup',
@@ -46,7 +46,7 @@ payloads = [
 {
        'service': 'ingress',
        'request_id': request_id,
-       'status': 'announced'
+       'status': 'success'
 },
 {
        'service': 'insights-advisor-service',
@@ -56,14 +56,16 @@ payloads = [
 {
        'service': 'insights-advisor-service',
        'request_id': request_id,
-       'status': 'processing',
-       'status_msg': 'analyzing archive'
+       'status': 'received',
+       'status_msg': 'analyzing archive',
+       'source': 'inventory'
 },
 {
        'service': 'insights-advisor-service',
        'request_id': request_id,
-       'status': 'processing',
-       'status_msg': 'generating reports'
+       'status': 'success',
+       'status_msg': 'generating reports',
+       'source': 'inventory'
 },
 {
        'service': 'insights-advisor-service',

--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,9 @@ class TripleSet():
     def values(self):
         return [item.value for item in self.data]
 
+    def items(self):
+        return [(item.key, item.value) for item in self.data]
+
     def append(self, value):
         if type(value) is Triple:
             self.data.append(value)


### PR DESCRIPTION
Updates the prometheus metrics and sockets to calculate based on individual sources (since each source should give a `success` and `received` message).

Updated Promql results for `mock_payload.py`:

![Screen Shot 2020-10-12 at 9 56 06 AM](https://user-images.githubusercontent.com/4829473/95754765-865cd280-0c71-11eb-89b8-4d73b4e30a93.png)

![Screen Shot 2020-10-12 at 9 56 46 AM](https://user-images.githubusercontent.com/4829473/95754801-907ed100-0c71-11eb-9cdc-bcfe0788f5d0.png)

Updated Dashboard for `mock_payload.py`:

![Screen Shot 2020-10-12 at 9 55 23 AM](https://user-images.githubusercontent.com/4829473/95754832-983e7580-0c71-11eb-8f8f-b2a5dac67e3a.png)
