### PR TITLE
Add asyncio queue in front of database to check connection

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -74,8 +74,8 @@ async def search(*args, **kwargs):
     for count in range(0, DB_RETRY_MAX):
         try:
             # supplying a timeout leverages `ensure_future` instead of `await` in asyncpg
-            conn = await db.bind.acquire(timeout=(DB_TIMEOUT_SECONDS * 1000))
-            await conn.release()
+            if not await db.has_connection(timeout=(DB_TIMEOUT_SECONDS * 1000)):
+                raise
             break
         except:
             if count == DB_RETRY_MAX - 1:

--- a/db.py
+++ b/db.py
@@ -1,6 +1,6 @@
 import config
-from gino import Gino
-db = Gino()
+from shielded_db import ShieldedDB
+db = ShieldedDB()
 
 
 async def init_db():

--- a/shielded_db.py
+++ b/shielded_db.py
@@ -1,0 +1,97 @@
+import traceback
+import logging
+import asyncio
+import settings
+from gino import Gino
+from asyncio import LifoQueue
+
+logger = logging.getLogger(settings.APP_NAME)
+
+
+class ShieldedDB(Gino):
+
+
+    def __init__(self):
+        self.queue = LifoQueue()
+        self.loop = asyncio.get_event_loop()
+        super().__init__()
+
+    async def push(self, creatable, callback, retry_logic=None):
+        '''
+        This method is used to add values to the queue, which retries if failure occurs
+        * creatable: should be of the form Payload(**payload)
+        * callback: contains a function to complete the actions within the transaction
+        '''
+        if self.queue.full():
+            await asyncio.sleep(0.1)
+            await self.push(creatable, callback, retry_logic)
+        else:
+            try:
+                await self.queue.put((creatable, callback, retry_logic))
+            except:
+                logger.error(f'Failed to insert into queue: {traceback.format_exc()}')
+                logger.debug(f'Retrying addition to queue -- sleeping first...')
+                await asyncio.sleep(0.1)
+                await self.push(creatable, callback, retry_logic)
+
+    async def pop(self):
+        '''
+        This method is used to pops a value from the queue
+        '''
+        try:
+            return await self.queue.get()
+        except:
+            logger.error(f'Failed to pop from queue: {traceback.format_exc()}')
+
+    async def has_connection(self, timeout=None):
+        '''
+        This method checks for database connection and is used before we start a transaction
+        '''
+        try:
+            await self.bind.acquire(timeout=timeout)
+        except:
+            return False
+        return True
+
+    async def insert(self, head, callback):
+        try:
+            async with self.transaction():
+                logger.error('In transaction...')
+                created = await head.create()
+                if asyncio.iscoroutinefunction(callback):
+                    await callback(created)
+                else:
+                    callback(created)
+            logger.error('Finished Transaction')
+        except:
+            logger.error(traceback.format_exc())
+            raise
+
+    async def _consume(self):
+        while not self.queue.empty():
+            if await self.has_connection():
+                logger.error('Consuming...')
+                try:
+                    (head, callback, retry_logic) = await self.pop()
+                    await self.insert(head, callback)
+                except:
+                    logger.error(f'Failed to insert payload: {traceback.format_exc()}')
+                    if retry_logic:
+                        if asyncio.iscoroutinefunction(retry_logic):
+                            await retry_logic(**{'head': head, 'callback': callback})
+                        else:
+                            retry_logic(**{'head': head, 'callback': callback})
+            else:
+                await asyncio.sleep(1)
+
+    async def consume(self):
+        '''
+        Use this method to initialize an insertion
+        '''
+        while True:
+            await asyncio.sleep(1)
+            if self.queue.empty():
+                await asyncio.sleep(1)
+            else:
+                self.loop.create_task(self._consume())
+


### PR DESCRIPTION
This PR creates a subclass of Gino which provides methods for queuing messages before insertion. The queue is continuously executed (while it contains data) using a task in the event loop. It also provides logic for callback and retry functions, which breaks up the `process_payload_status` function into distinct callback chunks, and requires waiting for certain pieces of code to run before executing the whole task.

I am currently running into issues where this implementation hangs while trying to run `await`. So... this may or may not work, but for now marking it as WIP.