### PR TITLE
Set autocommmit false and rework msg consumption

### DIFF
--- a/kafka_consumer.py
+++ b/kafka_consumer.py
@@ -1,8 +1,11 @@
 import os
+import logging
 import asyncio
 from aiokafka import AIOKafkaConsumer
 from kafkahelpers import ReconnectingClient
+import settings
 
+logger = logging.getLogger(settings.APP_NAME)
 
 BOOTSTRAP_SERVERS = os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')
 TOPIC = os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker')
@@ -12,11 +15,24 @@ GROUP_ID = os.environ.get('GROUP_ID', 'payload_tracker')
 class Consumer(AIOKafkaConsumer):
 
     def __init__(self, loop):
-        super().__init__(TOPIC, bootstrap_servers=BOOTSTRAP_SERVERS, loop=loop, group_id=GROUP_ID)
+        super().__init__(TOPIC, bootstrap_servers=BOOTSTRAP_SERVERS,
+            loop=loop, group_id=GROUP_ID, enable_auto_commit=False)
         self.client = ReconnectingClient(self, 'consumer')
 
-    def get_client(self):
-        return self.client
+    async def teardown(self):
+        try:
+            logger.info('Disconnecting client from Kafka...')
+            asyncio.get_event_loop()
+        except Exception as err:
+            logger.error(f'Failed to acquire event loop with error: {err}')
+        else:
+            await self.stop()
+
+    async def run(self, worker):
+        try:
+            await self.client.run(worker)
+        except asyncio.CancelledError:
+            await self.teardown()
 
 
 consumer = Consumer(asyncio.get_event_loop())


### PR DESCRIPTION
This PR updates the logic for how we process messages from Kafka. We are currently seeing some data loss overnight when pod restarts occur. The autocommit functionality of aiokafka processes the Kafka queue in batches and we lose data when the pod restarts and we execute a commit for the whole batch.