### PR TITLE
Scale consumption batch size based on current Kafka lag

### DIFF
--- a/kafka_consumer.py
+++ b/kafka_consumer.py
@@ -19,6 +19,11 @@ class Consumer(AIOKafkaConsumer):
             loop=loop, group_id=GROUP_ID, enable_auto_commit=False)
         self.client = ReconnectingClient(self, 'consumer')
 
+    @property
+    async def partition_lags(self):
+        return {p: 0 if not self.highwater(p) else (
+            self.highwater(p) - await self.position(p)) for p in self.assignment()}
+
     async def teardown(self):
         try:
             logger.info('Disconnecting client from Kafka...')


### PR DESCRIPTION
This PR makes changes on the fly to the batch size we are consuming based on the current Kafka lag.

This may help mitigate some of the drastic spikes that can occur by sequentially processing batches using `await` by mitigating the number of `await` calls during high volume times.

Observed Kafka lag spike:
<img width="1440" alt="Screen Shot 2020-11-02 at 2 51 20 PM" src="https://user-images.githubusercontent.com/4829473/97912647-1646e700-1d1b-11eb-88ef-619898fdf2a8.png">
