### PR TITLE
Add Redis caching for in-memory calculations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ aiohttp-jinja2 = "==1.2.0"
 python-socketio = "==4.6.0"
 psycopg2-binary = "==2.8.6"
 asyncpg = "==0.21.0"
+redis = "==3.5.3"
 
 [dev-packages]
 pytest = "==6.0.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "425bea38992ab43161b289f6abe28f65192a5fb7c097f9f367c6cde2ee650710"
+            "sha256": "bd4c58ee07d32752c78667916265b2dc4c108fc5f7e83205dbfcdae34fab8524"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -125,10 +125,10 @@
         },
         "clickclick": {
             "hashes": [
-                "sha256:4a890aaa9c3990cfabd446294eb34e3dc89701101ac7b41c1bff85fc210f6d23",
-                "sha256:ab8f229fb9906a86634bdfc6fabfc2b665f44804170720db4f6e1d98f8a58f3d"
+                "sha256:4efb13e62353e34c5eef7ed6582c4920b418d7dedc86d819e22ee089ba01802c",
+                "sha256:c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5"
             ],
-            "version": "==1.2.2"
+            "version": "==20.10.2"
         },
         "connexion": {
             "extras": [
@@ -340,13 +340,16 @@
                 "sha256:0deac2af1a587ae12836aa07970f5cb91964f05a7c6cdb69d8425ff4c15d4e2c",
                 "sha256:0e4dc3d5996760104746e6cfcdb519d9d2cd27c738296525d5867ea695774e67",
                 "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0",
+                "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6",
                 "sha256:1fabed9ea2acc4efe4671b92c669a213db744d2af8a9fc5d69a8e9bc14b7a9db",
                 "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94",
                 "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52",
+                "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056",
                 "sha256:6a32f3a4cb2f6e1a0b15215f448e8ce2da192fd4ff35084d80d5e39da683e79b",
                 "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd",
                 "sha256:7d92a09b788cbb1aec325af5fcba9fed7203897bbd9269d5691bb1e3bce29550",
                 "sha256:833709a5c66ca52f1d21d41865a637223b368c0ee76ea54ca5bad6f2526c7679",
+                "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83",
                 "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77",
                 "sha256:950bc22bb56ee6ff142a2cb9ee980b571dd0912b0334aa3fe0fe3788d860bea2",
                 "sha256:a0c50db33c32594305b0ef9abc0cb7db13de7621d2cadf8392a1d9b3c437ef77",
@@ -425,6 +428,14 @@
             ],
             "version": "==5.3.1"
         },
+        "redis": {
+            "hashes": [
+                "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2",
+                "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"
+            ],
+            "index": "pypi",
+            "version": "==3.5.3"
+        },
         "requests": {
             "hashes": [
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
@@ -490,15 +501,15 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.7'",
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "werkzeug": {
             "hashes": [
@@ -510,32 +521,48 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:040b237f58ff7d800e6e0fd89c8439b841f777dd99b4a9cca04d6935564b9409",
-                "sha256:17668ec6722b1b7a3a05cc0167659f6c95b436d25a36c2d52db0eca7d3f72593",
-                "sha256:3a584b28086bc93c888a6c2aa5c92ed1ae20932f078c46509a66dce9ea5533f2",
-                "sha256:4439be27e4eee76c7632c2427ca5e73703151b22cae23e64adb243a9c2f565d8",
-                "sha256:48e918b05850fffb070a496d2b5f97fc31d15d94ca33d3d08a4f86e26d4e7c5d",
-                "sha256:9102b59e8337f9874638fcfc9ac3734a0cfadb100e47d55c20d0dc6087fb4692",
-                "sha256:9b930776c0ae0c691776f4d2891ebc5362af86f152dd0da463a6614074cb1b02",
-                "sha256:b3b9ad80f8b68519cc3372a6ca85ae02cc5a8807723ac366b53c0f089db19e4a",
-                "sha256:bc2f976c0e918659f723401c4f834deb8a8e7798a71be4382e024bcc3f7e23a8",
-                "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6",
-                "sha256:c52ce2883dc193824989a9b97a76ca86ecd1fa7955b14f87bf367a61b6232511",
-                "sha256:ce584af5de8830d8701b8979b18fcf450cef9a382b1a3c8ef189bedc408faf1e",
-                "sha256:da456eeec17fa8aa4594d9a9f27c0b1060b6a75f2419fe0c00609587b2695f4a",
-                "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb",
-                "sha256:df89642981b94e7db5596818499c4b2219028f2a528c9c37cc1de45bf2fd3a3f",
-                "sha256:f18d68f2be6bf0e89f1521af2b1bb46e66ab0018faafa81d70f358153170a317",
-                "sha256:f379b7f83f23fe12823085cd6b906edc49df969eb99757f58ff382349a3303c6"
+                "sha256:03b7a44384ad60be1b7be93c2a24dc74895f8d767ea0bce15b2f6fc7695a3843",
+                "sha256:076157404db9db4bb3fa9db22db319bbb36d075eeab19ba018ce20ae0cacf037",
+                "sha256:1c05ae3d5ea4287470046a2c2754f0a4c171b84ea72c8a691f776eb1753dfb91",
+                "sha256:2467baf8233f7c64048df37e11879c553943ffe7f373e689711ec2807ea13805",
+                "sha256:2bb2e21cf062dfbe985c3cd4618bae9f25271efcad9e7be1277861247eee9839",
+                "sha256:311effab3b3828ab34f0e661bb57ff422f67d5c33056298bda4c12195251f8dd",
+                "sha256:3526cb5905907f0e42bee7ef57ae4a5f02bc27dcac27859269e2bba0caa4c2b6",
+                "sha256:39b1e586f34b1d2512c9b39aa3cf24c870c972d525e36edc9ee19065db4737bb",
+                "sha256:4bed5cd7c8e69551eb19df15295ba90e62b9a6a1149c76eb4a9bab194402a156",
+                "sha256:51c6d3cf7a1f1fbe134bb92f33b7affd94d6de24cd64b466eb12de52120fb8c6",
+                "sha256:59f78b5da34ddcffb663b772f7619e296518712e022e57fc5d9f921818e2ab7c",
+                "sha256:6f29115b0c330da25a04f48612d75333bca04521181a666ca0b8761005a99150",
+                "sha256:73d4e1e1ef5e52d526c92f07d16329e1678612c6a81dd8101fdcae11a72de15c",
+                "sha256:9b48d31f8d881713fd461abfe7acbb4dcfeb47cec3056aa83f2fbcd2244577f7",
+                "sha256:a1fd575dd058e10ad4c35065e7c3007cc74d142f622b14e168d8a273a2fa8713",
+                "sha256:b3dd1052afd436ba737e61f5d3bed1f43a7f9a33fc58fbe4226eb919a7006019",
+                "sha256:b99c25ed5c355b35d1e6dae87ac7297a4844a57dc5766b173b88b6163a36eb0d",
+                "sha256:c056e86bff5a0b566e0d9fab4f67e83b12ae9cbcd250d334cbe2005bbe8c96f2",
+                "sha256:c45b49b59a5724869899798e1bbd447ac486215269511d3b76b4c235a1b766b6",
+                "sha256:cd623170c729a865037828e3f99f8ebdb22a467177a539680dfc5670b74c84e2",
+                "sha256:d25d3311794e6c71b608d7c47651c8f65eea5ab15358a27f29330b3475e8f8e5",
+                "sha256:d695439c201ed340745250f9eb4dfe8d32bf1e680c16477107b8f3ce4bff4fdb",
+                "sha256:d77f6c9133d2aabb290a7846aaa74ec14d7b5ab35b01591fac5a70c4a8c959a2",
+                "sha256:d894a2442d2cd20a3b0b0dce5a353d316c57d25a2b445e03f7eac90eee27b8af",
+                "sha256:db643ce2b58a4bd11a82348225c53c76ecdd82bb37cf4c085e6df1b676f4038c",
+                "sha256:e3a0c43a26dfed955b2a06fdc4d51d2c51bc2200aff8ce8faf14e676ea8c8862",
+                "sha256:e77bf79ad1ccae672eab22453838382fe9029fc27c8029e84913855512a587d8",
+                "sha256:f2f0174cb15435957d3b751093f89aede77df59a499ab7516bbb633b77ead13a",
+                "sha256:f3031c78edf10315abe232254e6a36b65afe65fded41ee54ed7976d0b2cdf0da",
+                "sha256:f4c007156732866aa4507d619fe6f8f2748caabed4f66b276ccd97c82572620c",
+                "sha256:f4f27ff3dd80bc7c402def211a47291ea123d59a23f59fe18fc0e81e3e71f385",
+                "sha256:f57744fc61e118b5d114ae8077d8eb9df4d2d2c11e2af194e21f0c11ed9dcf6c",
+                "sha256:f835015a825980b65356e9520979a1564c56efea7da7d4b68a14d4a07a3a7336"
             ],
-            "version": "==1.5.1"
+            "version": "==1.6.2"
         },
         "zipp": {
             "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
             ],
-            "version": "==3.1.0"
+            "version": "==3.4.0"
         }
     },
     "develop": {
@@ -643,10 +670,10 @@
         },
         "iniconfig": {
             "hashes": [
-                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
-                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -657,10 +684,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
-                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
+                "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330",
+                "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"
             ],
-            "version": "==8.5.0"
+            "version": "==8.6.0"
         },
         "packaging": {
             "hashes": [
@@ -745,17 +772,17 @@
         },
         "toml": {
             "hashes": [
-                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
-                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "version": "==0.10.1"
+            "version": "==0.10.2"
         },
         "zipp": {
             "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
             ],
-            "version": "==3.1.0"
+            "version": "==3.4.0"
         }
     }
 }

--- a/api/payloads.py
+++ b/api/payloads.py
@@ -1,6 +1,6 @@
 from db import Payload, PayloadStatus, db
 from utils import dump, Triple, TripleSet
-from cache import cache
+from cache import redis_client
 from sqlalchemy import inspect, cast, TIMESTAMP
 from sqlalchemy.orm import Bundle
 from dateutil import parser
@@ -149,7 +149,7 @@ async def get(request_id, *args, **kwargs):
         for status in payload_statuses_dump:
             for column_name, table_name in zip(['service', 'source', 'status'], ['services', 'sources', 'statuses']):
                 if f'{column_name}_id' in status:
-                    status[column_name] = cache.get_value(table_name)[status[f'{column_name}_id']]
+                    status[column_name] = redis_client.hgetall(table_name, key_is_int=True)[status[f'{column_name}_id']]
                     del status[f'{column_name}_id']
 
         durations = _get_durations(payload_statuses_dump)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,12 @@ services:
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:29092
       - KAFKA_ADVERTISED_HOST_NAME=localhost
       - KAFKA_BROKER_ID=1
+      - KAFKA_NUM_PARTITIONS=4
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+  redis:
+    image: quay.io/cloudservices/redis
+    ports:
+      - 6379:6379
+    depends_on:
+      - payload-tracker-db

--- a/manual_tests/mock_loadtest.py
+++ b/manual_tests/mock_loadtest.py
@@ -6,14 +6,10 @@ from random import randint
 from confluent_kafka import Producer
 
 
-sources = ['compliance-sidekiq', 'inventory', 'insights-client', 'compliance-consumer']
-
-
 def generatePayloads():
     request_id = str(uuid.uuid4().hex)
     inventory_id = str(uuid.uuid4().hex)
     system_id = str(uuid.uuid4().hex)
-    source = sources[randint(0, len(sources) - 1)]
     account = str(randint(pow(10, 5), pow(10,6) - 1))
     print(f'request_id: {request_id}')
     return [
@@ -32,13 +28,13 @@ def generatePayloads():
         {
             'service': 'ingress',
             'request_id': request_id,
-            'status': 'validated',
+            'status': 'success',
             'account': account
         },
         {
             'service': 'advisor-pup',
             'request_id': request_id,
-            'status': 'processing',
+            'status': 'received',
             'inventory_id': inventory_id
         },
         {
@@ -57,32 +53,35 @@ def generatePayloads():
             'request_id': request_id,
             'status': 'received',
             'inventory_id': inventory_id,
-            'source': source
+            'source': 'inventory'
+        },
+        {
+            'service': 'insights-advisor-service',
+            'request_id': request_id,
+            'status': 'received',
+            'inventory_id': inventory_id,
+            'source': 'insights-client'
         },
         {
             'service': 'insights-advisor-service',
             'request_id': request_id,
             'status': 'processing',
-            'status_msg': 'analyzing archive',
-            'system_id': system_id
+            'inventory_id': inventory_id,
+            'source': 'insights-client'
         },
         {
             'service': 'insights-advisor-service',
             'request_id': request_id,
-            'status': 'processing',
-            'status_msg': 'generating reports'
+            'status': 'success',
+            'inventory_id': inventory_id,
+            'source': 'inventory'
         },
         {
             'service': 'insights-advisor-service',
             'request_id': request_id,
-            'status': 'processing',
-            'status_msg': 'performing db operations',
-            'inventory_id': inventory_id
-        },
-        {
-            'service': 'insights-advisor-service',
-            'request_id': request_id,
-            'status': 'success'
+            'status': 'success',
+            'inventory_id': inventory_id,
+            'source': 'insights-client'
         },
     ]
 

--- a/manual_tests/mock_payload.py
+++ b/manual_tests/mock_payload.py
@@ -18,75 +18,74 @@ def produceMessageCallback(err, msg):
 
 request_id = str(uuid.uuid4().hex)
 payloads = [
-{
-       'service': 'ingress',
-       'request_id': request_id,
-       'status': 'received'
-},
-{
-       'service': 'ingress',
-       'request_id': request_id,
-       'status': 'processing'
-},
-{
-       'service': 'ingress',
-       'request_id': request_id,
-       'status': 'validated'
-},
-{
-       'service': 'advisor-pup',
-       'request_id': request_id,
-       'status': 'received'
-},
-{
-       'service': 'advisor-pup',
-       'request_id': request_id,
-       'status': 'success'
-},
-{
-       'service': 'ingress',
-       'request_id': request_id,
-       'status': 'success'
-},
-{
-       'service': 'insights-advisor-service',
-       'request_id': request_id,
-       'status': 'received'
-},
-{
-       'service': 'insights-advisor-service',
-       'request_id': request_id,
-       'status': 'received',
-       'status_msg': 'analyzing archive',
-       'source': 'inventory'
-},
-{
-       'service': 'insights-advisor-service',
-       'request_id': request_id,
-       'status': 'success',
-       'status_msg': 'generating reports',
-       'source': 'inventory'
-},
-{
-       'service': 'insights-advisor-service',
-       'request_id': request_id,
-       'status': 'processing',
-       'status_msg': 'performing db operations'
-},
-{
-       'service': 'insights-advisor-service',
-       'request_id': request_id,
-       'status': 'success'
-},
+    {
+        'service': 'ingress',
+        'request_id': request_id,
+        'status': 'received'
+    },
+    {
+        'service': 'ingress',
+        'request_id': request_id,
+        'status': 'processing'
+    },
+    {
+        'service': 'ingress',
+        'request_id': request_id,
+        'status': 'validated'
+    },
+    {
+        'service': 'advisor-pup',
+        'request_id': request_id,
+        'status': 'received'
+    },
+    {
+        'service': 'advisor-pup',
+        'request_id': request_id,
+        'status': 'success'
+    },
+    {
+        'service': 'ingress',
+        'request_id': request_id,
+        'status': 'success'
+    },
+    {
+        'service': 'insights-advisor-service',
+        'request_id': request_id,
+        'status': 'received'
+    },
+    {
+        'service': 'insights-advisor-service',
+        'request_id': request_id,
+        'status': 'received',
+        'status_msg': 'analyzing archive',
+        'source': 'inventory'
+    },
+    {
+        'service': 'insights-advisor-service',
+        'request_id': request_id,
+        'status': 'success',
+        'status_msg': 'generating reports',
+        'source': 'inventory'
+    },
+    {
+        'service': 'insights-advisor-service',
+        'request_id': request_id,
+        'status': 'processing',
+        'status_msg': 'performing db operations'
+    },
+    {
+        'service': 'insights-advisor-service',
+        'request_id': request_id,
+        'status': 'success'
+    }
 ]
-
 
 print(f'Posting payload status with request_id: {request_id}')
 p = Producer({'bootstrap.servers': os.environ.get('BOOTSTRAP_SERVERS', 'localhost:29092')})
 for payload in payloads:
-  payload['date'] = str(datetime.datetime.utcnow())
-  p.poll(0)
-  p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
-            json.dumps(payload), callback=produceMessageCallback)
-  p.flush()
-  time.sleep(1)
+    payload['date'] = str(datetime.datetime.utcnow())
+    p.poll(0)
+    p.produce(os.environ.get('PAYLOAD_TRACKER_TOPIC', 'payload_tracker'),
+                json.dumps(payload), callback=produceMessageCallback)
+    p.flush()
+    time.sleep(1)

--- a/prometheus.py
+++ b/prometheus.py
@@ -1,14 +1,18 @@
 import os
+import attr
 import logging
 import settings
+import traceback
+from dateutil.parser import parse
 from aiohttp.web import middleware
 from prometheus_client import start_http_server, Info, Counter, Summary
+from cache import redis_client, SECONDS_TO_LIVE
 
 logger = logging.getLogger(settings.APP_NAME)
 
 
 # Define prometheus configuration
-PROMETHEUS_PORT = os.environ.get('PROMETHEUS_PORT', 8000)
+PROMETHEUS_PORT = int(os.environ.get('PROMETHEUS_PORT', 8000))
 SERVICE_STATUS_COUNTER = Counter('payload_tracker_service_status_counter',
                                  'Counters for services and their various statuses',
                                  ['service_name', 'status', 'source_name'])
@@ -59,3 +63,71 @@ async def prometheus_middleware(request, handler):
 def start_prometheus():
     logger.info("Using PROMETHEUS_PORT: %s", PROMETHEUS_PORT)
     start_http_server(PROMETHEUS_PORT)
+
+
+@attr.s
+class PrometheusRedisClient():
+    '''
+    Wraps the redis-py client with additional methods for storing and retrieving request data
+    '''
+
+    client = attr.ib()
+
+    def get_request_data(self, request_id):
+        def _decode(res):
+            for k, v in res.items():
+                if 'date' == k:
+                    res['date'] = parse(res['date'])
+                elif v == '':
+                    res[k] = None
+            return res
+
+        try:
+            services = self.client.lget(request_id)
+            data = {s: _decode(self.client.hgetall(request_id + s)) for s in services}
+        except:
+            logger.error(traceback.format_exc())
+        else:
+            output = {}
+            for k, v in data.items():
+                service = k.split(':')[0]
+                if service in output.keys():
+                    output[service].append(v)
+                else:
+                    output[service] = [v]
+            return output
+
+    def is_unique(self, **kwargs):
+        request_id, service, status, date, source = tuple(kwargs.values())
+        resp = self.get_request_data(request_id)
+        if service in resp:
+            resp = resp[service]
+            for entry in resp:
+                unique = set()
+                for k, v in entry.items():
+                    if k in kwargs.keys():
+                        unique.add(v == kwargs[k])
+                if False not in unique:
+                    return False
+        return True
+
+    def set_request_data(self, **kwargs):
+        if self.is_unique(**kwargs):
+            request_id, service, status, date, source = tuple(kwargs.values())
+            data = {k: str(v) if v else '' for k, v in kwargs.items() if k in ['status', 'date', 'source']}
+            try:
+                return self.client.pipeline().hset(
+                    request_id + f'{service}:{data["date"]}', mapping=data
+                ).expire(
+                    request_id + f'{service}:{data["date"]}', SECONDS_TO_LIVE
+                ).lpush(
+                    request_id, f'{service}:{data["date"]}'
+                ).expire(
+                    request_id, SECONDS_TO_LIVE
+                ).execute()
+            except:
+                logger.error(traceback.format_exc())
+        else:
+            return False
+
+prometheus_redis_client = PrometheusRedisClient(redis_client)


### PR DESCRIPTION
Adds Redis cache to the service and API to manage data which will be used to:

1. Calculate Prometheus metrics
2. Handle `services`, `statuses`, and `sources`

I have created a plain instance of redis-py, with a few overridden methods, and then a secondary "PrometheusRedisClient", which wraps the redis-client with functionality specific to our use-case with prometheus.