### PR TITLE
Remove REDIS_PASSWORD from payload tracker

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -6,7 +6,6 @@ from redis import Redis
 
 REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
 REDIS_PORT = int(os.environ.get('REDIS_PORT', 6379))
-REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', 'payloadtracker')
 SECONDS_TO_LIVE = int(os.environ.get('SECONDS_TO_LIVE', 100))
 logger = logging.getLogger(settings.APP_NAME)
 
@@ -29,4 +28,4 @@ class Client(Redis):
             logger.error(traceback.format_exc())
 
 
-redis_client = Client(host=REDIS_HOST, db=0, port=REDIS_PORT, password=REDIS_PASSWORD)
+redis_client = Client(host=REDIS_HOST, db=0, port=REDIS_PORT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,3 @@ services:
       - 6379:6379
     depends_on:
       - payload-tracker-db
-    environment:
-      - REDIS_PASSWORD=payloadtracker


### PR DESCRIPTION
Take the redis password out because it is disabled by default in elasticache.