### PR TITLE
Aggregate status metrics across multiple pods

### DIFF
--- a/dashboards/grafana-dashboard-clouddot-insights-payload-tracker-configmap.yaml
+++ b/dashboards/grafana-dashboard-clouddot-insights-payload-tracker-configmap.yaml
@@ -328,7 +328,7 @@ data:
           "pluginVersion": "7.2.1",
           "targets": [
             {
-              "expr": "avg_over_time(payload_tracker_api_response_count_total[$__interval])",
+              "expr": "sum(sum_over_time(payload_tracker_api_response_count_total[$__interval])) by (status)",
               "interval": "",
               "legendFormat": "{{status}}",
               "refId": "A"


### PR DESCRIPTION
When running multiple pods `avg_over_time(payload_tracker_api_response_count_total[$__interval])` returns the count of statuses for each pod individually. We would like to combine these into a single metric.