### PR TITLE
Add cloudwatch logging on error

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,8 @@ aiohttp-jinja2 = "==1.3.0"
 psycopg2-binary = "==2.8.6"
 asyncpg = "==0.21.0"
 redis = "==3.5.3"
+watchtower = "==1.0.0"
+boto3 = "==1.16.16"
 
 [dev-packages]
 pytest = "==6.1.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5edcfe0c8d4c4da2b76ecc922fc49676e1f75dbe1647b496773ad325a3d17332"
+            "sha256": "954e7846027dc1ab6d91ac6a6c9bb3773fc316250edd8ff10f2b3297d1b782ba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -123,12 +123,27 @@
             ],
             "version": "==18.2.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:218c783a0a1f0d867c6ccb577fbc5cffc817c37efbf3ad5bfecd28918d81164a",
+                "sha256:fb2304ad4e3428fcf942256874f20043f9f0150000a225f807246457771e6306"
+            ],
+            "index": "pypi",
+            "version": "==1.16.16"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:4a75c3b43dda666be0137c92f56ac57aceed87697e0b93fa8f1c6b8853df6024",
+                "sha256:8deda10476419156d50d40842604b319cebab70914e96d6e544a34656c54b295"
+            ],
+            "version": "==1.19.16"
+        },
         "certifi": {
             "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
-            "version": "==2020.6.20"
+            "version": "==2020.11.8"
         },
         "chardet": {
             "hashes": [
@@ -243,6 +258,13 @@
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
             "version": "==2.11.2"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "version": "==0.10.0"
         },
         "jsonschema": {
             "hashes": [
@@ -460,10 +482,17 @@
         },
         "requests": {
             "hashes": [
-                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
-                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
             ],
-            "version": "==2.24.0"
+            "version": "==2.25.0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
         },
         "six": {
             "hashes": [
@@ -537,7 +566,16 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.11"
+        },
+        "watchtower": {
+            "hashes": [
+                "sha256:2c25884f4c2387f57e26c4c44423d80ca24f6c1f0b71792cf99e515f65a46aca",
+                "sha256:f662de408e6f3945ad2bf9b9ac96681430ff19606e6522f9754c527f0a40b003"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
         },
         "werkzeug": {
             "hashes": [

--- a/api/health.py
+++ b/api/health.py
@@ -99,6 +99,7 @@ async def search(*args, **kwargs):
             redis_client.info()
         except Exception as err:
             if count == REDIS_RETRY_MAX - 1:
+                logger.error(f'{FAILED_MSG} with error: {traceback.format_exc()}')
                 return responses.failed(f'{FAILED_MSG} with error: {err}')
             await asyncio.sleep(REDIS_COUNT_TIMEOUT)
         else:

--- a/app.py
+++ b/app.py
@@ -136,7 +136,7 @@ async def process_payload_status(json_msgs):
                             sanitized_payload_status['payload_id'] = dump['id']
                             logger.debug(f"DB Transaction {created_payload} - {dump}")
                     except:
-                        logger.error(f'Failed to insert Payload into Table -- will retry update')
+                        logger.debug(f'Failed to insert Payload into Table -- will retry update')
                         payload_dump = await get_payload()
                         if payload_dump:
                             sanitized_payload_status['payload_id'] = payload_dump['id']
@@ -208,14 +208,14 @@ async def process_payload_status(json_msgs):
             try:
                 await insert_status(sanitized_payload_status)
             except Exception as err:
-                logger.error(f'Failed to insert PayloadStatus with ERROR: {err}')
+                logger.debug(f'Failed to insert PayloadStatus with ERROR: {err}')
                 # First, we assume there is no partition. If there is a further error, simply try reinsertion
                 try:
                     date = sanitized_payload_status['date']
                     await db.bind.scalar(f'SELECT create_partition(\'{date}\'::DATE, \'{date}\'::DATE + INTERVAL \'1 DAY\');')
                     await insert_status(sanitized_payload_status)
                 except Exception as err:
-                    logger.error(f'Failed to insert PayloadStatus with ERROR: {err}')
+                    logger.debug(f'Failed to insert PayloadStatus with ERROR: {err}')
                     try:
                         await insert_status(sanitized_payload_status)
                     except Exception as err:

--- a/settings.py
+++ b/settings.py
@@ -9,3 +9,12 @@ DEV_LOG_MSG_FORMAT = "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(linen
             "[%(thread)d  %(threadName)s] [%(process)d] %(message)s"
 DEV_LOG_DATE_FORMAT = "%H:%M:%S"
 APP_NAME = "payload-tracker-service"
+
+# watchtower logging settings
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
+AWS_REGION_NAME = os.environ.get('AWS_REGION_NAME')
+CW_LOG_GROUP = os.environ.get('CW_LOG_GROUP', 'platform-dev')
+CW_LOG_STREAM_MANUAL = os.environ.get('CW_LOG_STREAM')
+CW_CREATE_LOG_GROUP = os.environ.get('CW_CREATE_LOG_GROUP', "").lower() == "true"
+CW_LOG_STREAM_AUTO = os.environ.get('HOSTNAME', 'payload-tracker-dev')

--- a/tracker_logging.py
+++ b/tracker_logging.py
@@ -5,6 +5,8 @@ import sys
 import traceback
 from logstash_formatter import LogstashFormatterV1
 import settings
+import watchtower
+from boto3 import Session
 
 
 class TrackerStreamHandler(logging.StreamHandler):
@@ -26,6 +28,57 @@ class OurFormatter(LogstashFormatterV1):
         return super(OurFormatter, self).format(record)
 
 
+class LoggerWrapper(logging.Logger):
+
+    def __init__(self, baseLogger):
+        self.__class__ = type(baseLogger.__class__.__name__,
+                             (self.__class__, baseLogger.__class__),
+                             {})
+        self.__dict__ = baseLogger.__dict__
+        self.cwHandler = self.init_cw()
+
+    def init_cw(self):
+        """ initialize watchtower logging handler """
+        cw_handler = None
+        if (settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY):
+            try:
+                CW_SESSION = Session(aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                                    region_name=settings.AWS_REGION_NAME)
+
+                cw_log_stream_manual = settings.CW_LOG_STREAM_MANUAL
+                cw_log_stream_auto = settings.CW_LOG_STREAM_AUTO
+                cw_log_stream = cw_log_stream_manual if cw_log_stream_manual else cw_log_stream_auto
+                create_log_group = settings.CW_CREATE_LOG_GROUP
+                self.debug("Creating cloud watch log handler...")
+                cw_handler = watchtower.CloudWatchLogHandler(boto3_session=CW_SESSION,
+                                                            log_group=settings.CW_LOG_GROUP,
+                                                            stream_name=cw_log_stream,
+                                                            create_log_group=create_log_group)
+                cw_handler.setFormatter(
+                    OurFormatter(fmt=json.dumps({"extra": {"component": settings.APP_NAME}})))
+                self.debug("Cloud watch handler configured")
+            except:
+                self.exception("Cloud watch logging setup encountered an Exception")
+        return cw_handler
+
+    def error(self, msg, *args, **kwargs):
+        """ override the logging.Logger error method to provide watchtower logging """
+        if self.cwHandler:
+            handlerConfigured = False
+            try:
+                self.addHandler(self.cwHandler)
+                handlerConfigured = True
+                super(LoggerWrapper, self).error(msg, *args, **kwargs)
+            except Exception as err:
+                self.exception(err)
+            finally:
+                if handlerConfigured:
+                    self.removeHandler(self.cwHandler)
+        else:
+            super(LoggerWrapper, self).error(msg, *args, **kwargs)
+
+
 def initialize_logging():
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
 
@@ -39,6 +92,7 @@ def initialize_logging():
                         format=settings.DEV_LOG_MSG_FORMAT,
                         datefmt=settings.DEV_LOG_DATE_FORMAT)
 
-    # return app logger
-    logger = logging.getLogger(settings.APP_NAME)
-    return logger
+    # overwrite RootLogger and return
+    logging.root = LoggerWrapper(logging.getLogger(settings.APP_NAME))
+    logging.root.manager.loggerDict[settings.APP_NAME] = logging.root
+    return logging.getLogger(settings.APP_NAME)


### PR DESCRIPTION
This PR adds a wrapper class around the logger object in order to override the logger's error method. In the new error method we add the watchtower logging handler to write error logs to cloudwatch and then remove the handler to make sure we are **only** logging error messages to cloudwatch.