### PR TITLE
Add number of running tasks to logged output

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -6,7 +6,7 @@ DEBUG = ENVIRONMENT in ('dev', 'ci', 'qa')
 # Logging settings
 DEV_LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
 DEV_LOG_MSG_FORMAT = "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] " \
-            "[%(thread)d  %(threadName)s] [%(process)d] %(message)s"
+            "[%(thread)d  %(threadName)s] [%(process)d] [%(tasks)s] %(message)s"
 DEV_LOG_DATE_FORMAT = "%H:%M:%S"
 APP_NAME = "payload-tracker-service"
 


### PR DESCRIPTION
Each log message now will come with the number of currently running tasks included.

When `ENVIRONMENT=dev`:
```
[14:42:24] INFO [gino.engine._SAEngine._execute_context:1239] [4653858240  MainThread] [68018] [12 running task(s)]
```

When `ENVIRONMENT!=dev`:
```
{"component": "payload-tracker-service", "tasks": 7, "@timestamp": "2020-11-13T19:50:38.600Z", "@version": 1, "source_host": "MacBook-Pro", "name": "aiokafka.consumer.group_coordinator", "args": ["payload_tracker", 198, "aiokafka-0.5.2-56f81ef3-1365-453b-9062-cc6bd6cf901a"], "levelname": "INFO", "levelno": 20, "pathname": "/Users/lmccann/.local/share/virtualenvs/payload-tracker-kcWfGmZC/lib/python3.6/site-packages/aiokafka/consumer/group_coordinator.py", "filename": "group_coordinator.py", "module": "group_coordinator", "stack_info": null, "lineno": 1260, "funcName": "perform_group_join", "created": 1605297038.600213, "msecs": 600.2130508422852, "relativeCreated": 7080.547094345093, "thread": 4590087616, "threadName": "MainThread", "processName": "MainProcess", "process": 69720, "message": "Joined group 'payload_tracker' (generation 198) with member_id aiokafka-0.5.2-56f81ef3-1365-453b-9062-cc6bd6cf901a"}
```

Here's an example in stage: https://kibana.apps.crc-stg-01.o4v9.p1.openshiftapps.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(tasks),filters:!(),index:'6c31b1b0-d854-11ea-9f21-6b7e641a18be',interval:auto,query:(language:kuery,query:'@log_group:%20%22payload-tracker-stage%22'),sort:!())