### PR TITLE
Set limit on number of tasks being run concurrently

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ API_PORT = int(os.environ.get('API_PORT', 8080))
 VALIDATE_REQUEST_ID = os.environ.get('VALIDATE_REQUEST_ID', "true").lower() == "true"
 VALIDATE_REQUEST_ID_LENGTH = os.environ.get('VALIDATE_REQUEST_ID_LENGTH', 32)
 DISABLE_PROMETHEUS = True if os.environ.get('DISABLE_PROMETHEUS') == "True" else False
-KAFKA_BATCH_SIZE = int(os.environ.get('KAFKA_BATCH_SIZE', 100))
+MAXIMUM_RUNNING_TASKS = int(os.environ.get('MAXIMUM_RUNNING_TASKS', 50))
 
 # Setup logging
 logger = tracker_logging.initialize_logging()
@@ -229,18 +229,15 @@ async def process_payload_status(json_msgs):
 
 
 async def consume(consumer):
-    batch = []
-    async for msg in consumer:
-        batch.append(msg)
-        if len(batch) >= KAFKA_BATCH_SIZE:
-            logger.debug("Received messages: %s", batch)
-            try:
-                await process_payload_status(batch)
-            except:
-                continue
-            else:
-                await consumer.commit()
-                batch = []
+    def get_running_tasks():
+        return len([t for t in asyncio.Task.all_tasks() if not t.done()])
+
+    data = await consumer.getmany()
+    for tp, msgs in data.items():
+        while get_running_tasks() >= MAXIMUM_RUNNING_TASKS:
+            await asyncio.sleep(0.1)
+        loop.create_task(process_payload_status(msgs))
+    await asyncio.sleep(0.1)
 
 
 async def setup_db():

--- a/kafka_consumer.py
+++ b/kafka_consumer.py
@@ -15,8 +15,7 @@ GROUP_ID = os.environ.get('GROUP_ID', 'payload_tracker')
 class Consumer(AIOKafkaConsumer):
 
     def __init__(self, loop):
-        super().__init__(TOPIC, bootstrap_servers=BOOTSTRAP_SERVERS,
-            loop=loop, group_id=GROUP_ID, enable_auto_commit=False)
+        super().__init__(TOPIC, bootstrap_servers=BOOTSTRAP_SERVERS, loop=loop, group_id=GROUP_ID)
         self.client = ReconnectingClient(self, 'consumer')
 
     async def teardown(self):


### PR DESCRIPTION
This PR will make the consumption task wait for the number of tasks currently being run to drop below a certain threshold before starting any new tasks.