### PR TITLE
Add RequestClient for handling payloads in Redis cache

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,9 +1,11 @@
 import os
+import time
+import attr
 import logging
 import settings
 import traceback
-import time
 from redis import Redis
+from dateutil.parser import parse
 from prometheus_client import Summary
 
 REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
@@ -45,3 +47,96 @@ class Client(Redis):
 
 
 redis_client = Client(host=REDIS_HOST, db=0, port=REDIS_PORT)
+
+
+# Define RequestClient postprocessing function for request_client.get
+def get_msgs_by_service(data):
+    """ postprocessing function for request_client.get """
+    msgs_by_service = {}
+    for values in data.values():
+        entry = values.copy() # ensure we have "source" defined
+        if 'source' not in values:
+            entry['source'] = None
+        service = entry['service']
+        del entry['service']
+        if service in msgs_by_service.keys():
+            msgs_by_service[service].append(entry)
+        else:
+            msgs_by_service[service] = [entry]
+    return msgs_by_service
+
+
+def get_unique_values(data):
+    """ postprocessing function for request_client.get """
+    unique_values = {}
+    for entry in data.values():
+        for k in entry.keys():
+            # check for existing sanitized_payload values in the cache
+            if k in ['id', 'inventory_id', 'system_id', 'account'] and k not in unique_values:
+                unique_values[k] = entry[k]
+    return None if not len(unique_values) > 0 else unique_values
+
+
+# Define wrapper for redis_client which handles payloads in and out of the cache
+@attr.s
+class RequestClient():
+
+    POSTPROCESS_FUNCTIONS = {
+        'BY_SERVICE': get_msgs_by_service,
+        'UNIQUE_VALUES': get_unique_values
+    }
+
+    client = attr.ib()
+
+    def get(self, request_id, postprocess = None):
+        def _decode(res):
+            for k, v in res.items():
+                if 'date' == k:
+                    res['date'] = parse(res['date'])
+                elif v == '':
+                    res[k] = None
+            return res
+
+        try:
+            dates = self.client.lget(request_id) # "date" is the key-value store key
+            data = {date: _decode(self.client.hgetall(request_id + date)) for date in dates}
+        except:
+            logger.error(traceback.format_exc())
+        else:
+            if postprocess and postprocess in self.POSTPROCESS_FUNCTIONS:
+                return self.POSTPROCESS_FUNCTIONS[postprocess](data)
+            else:
+                return data
+
+    def is_unique(self, request_id, msg):
+        data = self.get(request_id)
+        for entry in data.values():
+            unique = set()
+            for k, v in entry.items():
+                if k in msg.keys():
+                    unique.add(v == msg[k])
+            if False not in unique:
+                return False
+        return True
+
+    def set(self, msg):
+        request_id = msg['request_id']
+        del msg['request_id']
+        if self.is_unique(request_id, msg):
+            data = {k: str(v) if v else '' for k, v in msg.items()}
+            try:
+                return self.client.pipeline().hset(
+                    request_id + data['date'], mapping=data
+                ).expire(
+                    request_id + data['date'], SECONDS_TO_LIVE
+                ).lpush(
+                    request_id, data['date']
+                ).expire(
+                    request_id, SECONDS_TO_LIVE
+                ).execute()
+            except:
+                logger.error(traceback.format_exc())
+        else:
+            return False
+
+request_client = RequestClient(redis_client)

--- a/prometheus.py
+++ b/prometheus.py
@@ -1,9 +1,7 @@
 import os
-import attr
 import logging
 import settings
 import traceback
-from dateutil.parser import parse
 from aiohttp.web import middleware
 from prometheus_client import start_http_server, Info, Counter, Summary
 from cache import redis_client, SECONDS_TO_LIVE
@@ -65,71 +63,3 @@ async def prometheus_middleware(request, handler):
 def start_prometheus():
     logger.info("Using PROMETHEUS_PORT: %s", PROMETHEUS_PORT)
     start_http_server(PROMETHEUS_PORT)
-
-
-@attr.s
-class PrometheusRedisClient():
-    '''
-    Wraps the redis-py client with additional methods for storing and retrieving request data
-    '''
-
-    client = attr.ib()
-
-    def get_request_data(self, request_id):
-        def _decode(res):
-            for k, v in res.items():
-                if 'date' == k:
-                    res['date'] = parse(res['date'])
-                elif v == '':
-                    res[k] = None
-            return res
-
-        try:
-            services = self.client.lget(request_id)
-            data = {s: _decode(self.client.hgetall(request_id + s)) for s in services}
-        except:
-            logger.error(traceback.format_exc())
-        else:
-            output = {}
-            for k, v in data.items():
-                service = k.split(':')[0]
-                if service in output.keys():
-                    output[service].append(v)
-                else:
-                    output[service] = [v]
-            return output
-
-    def is_unique(self, **kwargs):
-        request_id, service, status, date, source = tuple(kwargs.values())
-        resp = self.get_request_data(request_id)
-        if service in resp:
-            resp = resp[service]
-            for entry in resp:
-                unique = set()
-                for k, v in entry.items():
-                    if k in kwargs.keys():
-                        unique.add(v == kwargs[k])
-                if False not in unique:
-                    return False
-        return True
-
-    def set_request_data(self, **kwargs):
-        if self.is_unique(**kwargs):
-            request_id, service, status, date, source = tuple(kwargs.values())
-            data = {k: str(v) if v else '' for k, v in kwargs.items() if k in ['status', 'date', 'source']}
-            try:
-                return self.client.pipeline().hset(
-                    request_id + f'{service}:{data["date"]}', mapping=data
-                ).expire(
-                    request_id + f'{service}:{data["date"]}', SECONDS_TO_LIVE
-                ).lpush(
-                    request_id, f'{service}:{data["date"]}'
-                ).expire(
-                    request_id, SECONDS_TO_LIVE
-                ).execute()
-            except:
-                logger.error(traceback.format_exc())
-        else:
-            return False
-
-prometheus_redis_client = PrometheusRedisClient(redis_client)


### PR DESCRIPTION
This PR removes the PrometheusRedisClient class in favor of a new RequestClient class. This class defines methods which are better for handling general payload insertions and retrievals from the cache. The `get` method also allows for specification of a postprocessing function, which will interpolate the cached data according to the use case.