### PR TITLE
Update CloudWatch logging using StreamHandler

### DIFF
--- a/tracker_logging.py
+++ b/tracker_logging.py
@@ -55,55 +55,25 @@ class DevStreamHandler(logging.StreamHandler):
         super(DevStreamHandler, self).emit(record)
 
 
-class LoggerWrapper(logging.Logger):
+class CWStreamHandler(watchtower.CloudWatchLogHandler):
 
-    def __init__(self, baseLogger):
-        self.__class__ = type(baseLogger.__class__.__name__,
-                             (self.__class__, baseLogger.__class__),
-                             {})
-        self.__dict__ = baseLogger.__dict__
-        self.cwHandler = self.init_cw()
+    def __init__(self):
+        CW_SESSION = Session(aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                             region_name=settings.AWS_REGION_NAME)
 
-    def init_cw(self):
-        """ initialize watchtower logging handler """
-        cw_handler = None
-        if (settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY):
-            try:
-                CW_SESSION = Session(aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-                                    region_name=settings.AWS_REGION_NAME)
+        cw_log_stream_manual = settings.CW_LOG_STREAM_MANUAL
+        cw_log_stream_auto = settings.CW_LOG_STREAM_AUTO
+        cw_log_stream = cw_log_stream_manual if cw_log_stream_manual else cw_log_stream_auto
+        create_log_group = settings.CW_CREATE_LOG_GROUP
+        super().__init__(boto3_session=CW_SESSION,
+                         log_group=settings.CW_LOG_GROUP,
+                         stream_name=cw_log_stream,
+                         create_log_group=create_log_group)
 
-                cw_log_stream_manual = settings.CW_LOG_STREAM_MANUAL
-                cw_log_stream_auto = settings.CW_LOG_STREAM_AUTO
-                cw_log_stream = cw_log_stream_manual if cw_log_stream_manual else cw_log_stream_auto
-                create_log_group = settings.CW_CREATE_LOG_GROUP
-                self.debug("Creating cloud watch log handler...")
-                cw_handler = watchtower.CloudWatchLogHandler(boto3_session=CW_SESSION,
-                                                            log_group=settings.CW_LOG_GROUP,
-                                                            stream_name=cw_log_stream,
-                                                            create_log_group=create_log_group)
-                cw_handler.setFormatter(
-                    OurFormatter(fmt=json.dumps({"extra": {"component": settings.APP_NAME}})))
-                self.debug("Cloud watch handler configured")
-            except:
-                self.exception("Cloud watch logging setup encountered an Exception")
-        return cw_handler
-
-    def error(self, msg, *args, **kwargs):
-        """ override the logging.Logger error method to provide watchtower logging """
-        if self.cwHandler:
-            handlerConfigured = False
-            try:
-                self.addHandler(self.cwHandler)
-                handlerConfigured = True
-                super(LoggerWrapper, self).error(msg, *args, **kwargs)
-            except Exception as err:
-                self.exception(err)
-            finally:
-                if handlerConfigured:
-                    self.removeHandler(self.cwHandler)
-        else:
-            super(LoggerWrapper, self).error(msg, *args, **kwargs)
+    def emit(self, message):
+        if message.levelname.upper() == 'ERROR':
+            return super().emit(message)
 
 
 def initialize_logging():
@@ -114,13 +84,17 @@ def initialize_logging():
         if not logging.root.hasHandlers():
             logging.root.setLevel(LOG_LEVEL)
             logging.root.addHandler(TrackerStreamHandler())
+            if (settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY):
+                logging.root.addHandler(CWStreamHandler())
     else:
+        if (settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY):
+            handlers=[DevStreamHandler(), CWStreamHandler()]
+        else:
+            handlers=[DevStreamHandler()]
         logging.basicConfig(level=logging.getLevelName(settings.DEV_LOG_LEVEL),
                             format=settings.DEV_LOG_MSG_FORMAT,
                             datefmt=settings.DEV_LOG_DATE_FORMAT,
-                            handlers=[DevStreamHandler()])
+                            handlers=handlers)
 
     # overwrite RootLogger and return
-    logging.root = LoggerWrapper(logging.getLogger(settings.APP_NAME))
-    logging.root.manager.loggerDict[settings.APP_NAME] = logging.root
     return logging.getLogger(settings.APP_NAME)


### PR DESCRIPTION
Currently, not all error messages are able to be tracked in Kibana. Key errors like the error below are not able to be traced.

```
Traceback (most recent call last):
  File "app.py", line 197, in process_payload_status
    'source': None if 'source' not in data else data['source']
  File "app.py", line 44, in evaluate_status_metrics
    data = request_client.get(request_id, postprocess='BY_SERVICE')
  File "/opt/app-root/src/cache.py", line 107, in get
    return self.POSTPROCESS_FUNCTIONS[postprocess](data)
  File "/opt/app-root/src/cache.py", line 60, in get_msgs_by_service
    service = entry['service']
KeyError: 'service'
```

However, this issue extends to all error messages that are not being thrown from inside of our service code (i.e. from any external deps).