### PR TITLE
Add USE_REDIS toggle and use bakery for common db queries

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ kafkahelpers = "==0.3.3"
 sqlalchemy = "==1.3.20"
 werkzeug = "==1.0.1"
 connexion = {extras = ["swagger-ui"],version = "==2.7.0"}
-gino = "==1.0.1"
+gino = "==1.1.0b2"
 alembic = "==1.4.3"
 aiohttp = "==3.7.2"
 aiohttp-jinja2 = "==1.3.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65ce4aecad3d9f9d56c94e2e8e62f2310bb3e3dfd75a746a17f11fc02e886146"
+            "sha256": "6e64868704745e7a08ade65a2fb4fa2312ecffbb8ad89c12cb1ae145387f442f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -69,6 +69,13 @@
             ],
             "index": "pypi",
             "version": "==0.5.2"
+        },
+        "aiomysql": {
+            "hashes": [
+                "sha256:5fd798481f16625b424eec765c56d712ac78a51f3bd0175a3de94107aae43307",
+                "sha256:d89ce25d44dadb43cf2d9e4603bd67b7a0ad12d5e67208de013629ba648df2ba"
+            ],
+            "version": "==0.0.20"
         },
         "aioredis": {
             "hashes": [
@@ -142,10 +149,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:97741448e63850895818193c29b93ec6319135587ae4994a6f611ffccb1a978e",
-                "sha256:d8dab9b74dc0ad2e5439e5ea3c119e234d2f02952f37f379d9a74adfa305ed75"
+                "sha256:240a727c5e017199ab9af2ff13fd1fe5d226963cc93f63b68db90be6283aef2a",
+                "sha256:9d60dc6bcb88ece9ed6a3def353e43393fb00dc4e8328ceb12de41452de24760"
             ],
-            "version": "==1.19.28"
+            "version": "==1.19.29"
         },
         "certifi": {
             "hashes": [
@@ -153,6 +160,47 @@
                 "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
             "version": "==2020.11.8"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e",
+                "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d",
+                "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a",
+                "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec",
+                "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362",
+                "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668",
+                "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c",
+                "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b",
+                "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06",
+                "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698",
+                "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2",
+                "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c",
+                "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7",
+                "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
+                "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
+                "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
+                "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
+                "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
+                "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
+                "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
+                "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
+                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
+                "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
+                "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
+                "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
+                "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
+                "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
+                "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
+                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
+                "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
+                "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
+                "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
+                "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375",
+                "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b",
+                "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b",
+                "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"
+            ],
+            "version": "==1.14.4"
         },
         "chardet": {
             "hashes": [
@@ -194,6 +242,34 @@
             "markers": "python_version < '3.7'",
             "version": "==2.4"
         },
+        "cryptography": {
+            "hashes": [
+                "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538",
+                "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f",
+                "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77",
+                "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b",
+                "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33",
+                "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e",
+                "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb",
+                "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e",
+                "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7",
+                "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297",
+                "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d",
+                "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7",
+                "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b",
+                "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7",
+                "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4",
+                "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8",
+                "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b",
+                "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851",
+                "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13",
+                "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b",
+                "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3",
+                "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.2.1"
+        },
         "flask": {
             "hashes": [
                 "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
@@ -204,11 +280,11 @@
         },
         "gino": {
             "hashes": [
-                "sha256:56df57cfdefbaf897a7c4897c265a0e91a8cca80716fb64f7d3cf6d501fdfb3d",
-                "sha256:fe4189e82fe9d20c4a5f03fc775fb91c168061c5176b4c95623caeef22316150"
+                "sha256:c1b3ed4c88181c30ff54d0edd3f53f43da786b925efac1510b9a1dcf495d8ee6",
+                "sha256:fc6510599ae4d21ef9d1d1efe34e9505b199f153581874eef51db2de94804811"
             ],
             "index": "pypi",
-            "version": "==1.0.1"
+            "version": "==1.1.0b2"
         },
         "hiredis": {
             "hashes": [
@@ -454,6 +530,15 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
+        "mysqlclient": {
+            "hashes": [
+                "sha256:4c82187dd6ab3607150fbb1fa5ef4643118f3da122b8ba31c3149ddd9cf0cb39",
+                "sha256:9e6080a7aee4cc6a06b58b59239f20f1d259c1d2fddf68ddeed242d2311c7087",
+                "sha256:f3fdaa9a38752a3b214a6fe79d7cae3653731a53e577821f9187e67cbecb2e16",
+                "sha256:f646f8d17d02be0872291f258cce3813497bc7888cd4712a577fd1e719b2f213"
+            ],
+            "version": "==1.4.6"
+        },
         "openapi-spec-validator": {
             "hashes": [
                 "sha256:6dd75e50c94f1bb454d0e374a56418e7e06a07affb2c7f1df88564c5d728dac3",
@@ -510,6 +595,21 @@
             ],
             "index": "pypi",
             "version": "==2.8.6"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.20"
+        },
+        "pymysql": {
+            "hashes": [
+                "sha256:95f057328357e0e13a30e67857a8c694878b0175797a9a203ee7adbfb9b1ec5f",
+                "sha256:9ec760cbb251c158c19d6c88c17ca00a8632bac713890e465b2be01fdc30713f"
+            ],
+            "version": "==0.9.2"
         },
         "pyrsistent": {
             "hashes": [

--- a/bakery.py
+++ b/bakery.py
@@ -1,0 +1,94 @@
+import asyncio
+import traceback
+
+from db import db, Payload, Services, Sources, Statuses
+
+
+'''
+Define queries which will be pre-baked for execution by gino
+Using the bakery improves the execution time of the query
+It is suggested to utilize the bakery for heavily used queries
+'''
+
+get_services = db.bake(Services.query)
+get_statuses = db.bake(Statuses.query)
+get_sources = db.bake(Sources.query)
+get_payload_by_request_id = db.bake(
+    Payload.query.where(Payload.request_id == db.bindparam('request_id'))
+)
+
+
+BAKERY = {
+    'SERVICES': get_services,
+    'STATUSES': get_statuses,
+    'SOURCES': get_sources,
+    'PAYLOADS': get_payload_by_request_id,
+    'UNIQUE_VALUES': get_payload_by_request_id
+}
+
+
+'''
+Often times we would like to parse query results before returning their values
+Adding a processing function allows us to logically group the baked query with
+its processing function. The processing function MUST take a bakery_query which
+will be executed using one of gino's provided db api calls.
+
+Example:
+
+def test_function(baked_query, **bound_params):
+    return await baked_query.first(request_id=bound_params['request_id'])
+
+'''
+
+async def process_services_statuses_sources(baked_query, **bound_params):
+    try:
+        table_results_as_objs = await baked_query.all()
+        tables_dump = [table_obj.dump() for table_obj in table_results_as_objs]
+        values_in_table = {table_dict['id']: table_dict['name'] for table_dict in tables_dump}
+    except Exception as err:
+        raise err
+    else:
+        return values_in_table
+
+
+async def process_payload_by_request_id(baked_query, **bound_params):
+    try:
+        payload_obj = await baked_query.first(request_id=bound_params['request_id'])
+    except Exception as err:
+        raise err
+    else:
+        return None if not payload_obj else payload_obj.dump()
+
+
+async def process_payload_by_unique_keys(baked_query, **bound_params):
+    try:
+        payload_list = await baked_query.all(request_id=bound_params['request_id'])
+        payload_dump = [payload.dump() for payload in payload_list]
+        values = {k: v for payload in payload_dump for k, v in payload.items() if v is not None}
+    except Exception as err:
+        raise err
+    else:
+        return values
+
+
+PROCESSING_FUNCTIONS = {
+    'SERVICES': process_services_statuses_sources,
+    'STATUSES': process_services_statuses_sources,
+    'SOURCES': process_services_statuses_sources,
+    'PAYLOADS': process_payload_by_request_id,
+    'UNIQUE_VALUES': process_payload_by_unique_keys
+}
+
+
+'''
+Use this function to return the results of the processing function
+The key provided MUST match both the PROCESSING_FUNCTION AND BAKERY key
+'''
+async def exec_baked(key, **bound_params):
+    try:
+        key = key.upper()
+        res = await PROCESSING_FUNCTIONS[key](BAKERY[key], **bound_params)
+    except Exception as err:
+        raise err
+    else:
+        return res

--- a/db.py
+++ b/db.py
@@ -8,6 +8,7 @@ MIN_POOL_SIZE = int(os.environ.get('MIN_POOL_SIZE', 20))
 
 
 async def init_db():
+    import bakery # baked queries must be added to db before engine bind is set
     await db.set_bind('asyncpg://{}:{}@{}:{}/{}'.format(config.db_user,
                                                            config.db_password,
                                                            config.db_host,


### PR DESCRIPTION
This PR adds a `USE_REDIS` toggle, which allows us to turn on the functionality provided by redis/elasticache.

By doing this we must turn off the metrics which are computed in the `evaluate_status_metrics` function. This is a known drawback of this implementation. In order to keep the pods scaled up we cannot maintain payload data in memory. Therefore, without a shared cache such as redis we cannot scale up the pods.

This PR also introduces the notion of a Gino Bakery. The Bakery allows us to have ready-made queries available for execution. These are more efficient than creating a new query on each call. The implementation in this PR allows for the results of the query to be process into desired format before returning the result to the function caller. This reduces redundancy in the code and hopefully improves the overall readability.