### PR TITLE
Use database when data cannot be found in cache 

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -10,9 +10,10 @@ from dateutil.parser import parse
 from aioredis import Redis, create_connection
 from prometheus_client import Summary
 
+from bakery import exec_baked
+
 REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
 REDIS_PORT = int(os.environ.get('REDIS_PORT', 6379))
-SECONDS_TO_LIVE = int(os.environ.get('SECONDS_TO_LIVE', 100))
 logger = logging.getLogger(settings.APP_NAME)
 REDIS_LATENCY = Summary('payload_tracker_redis_latency',
                         'Tracks latency in requests to Redis',
@@ -61,7 +62,7 @@ class Client(Redis):
             lrange = await self.lrange(key, 0, llen - 1) # lrange is inclusive
             return [item.decode() for item in lrange]
         except:
-            logger.error(traceback.format_exc())
+            raise
 
 
 redis_client = Client()
@@ -89,7 +90,7 @@ def get_msgs_by_service(data):
                 msgs_by_service[service] = [entry]
     except Exception as err:
         raise err
-    return None if not len(msgs_by_service) > 0 else msgs_by_service
+    return msgs_by_service
 
 
 def get_unique_values(data):
@@ -103,7 +104,7 @@ def get_unique_values(data):
                     unique_values[k] = entry[k]
     except Exception as err:
         raise err
-    return None if not len(unique_values) > 0 else unique_values
+    return unique_values
 
 
 @attr.s
@@ -115,6 +116,21 @@ class RequestClient:
     }
 
     client = attr.ib()
+    expiration = int(os.environ.get('SECONDS_TO_LIVE', 100))
+
+    async def get_request_id_hash(self, request_id):
+        hashvalue = await self.client.get(request_id)
+        return None if not hashvalue else hashvalue.decode()
+
+    async def set_request_id_hash(self, request_id):
+        hashvalue = await self.get_request_id_hash(request_id)
+        if not hashvalue:
+            hashvalue = secrets.token_hex(nbytes=16)
+            await self.client.set(request_id, hashvalue)
+        return hashvalue
+
+    def update_request_id_hash(self, request_id, request_hash):
+        return self.client.set(request_id, request_hash)
 
     async def get(self, request_id, postprocess=None):
         def _decode(res):
@@ -126,23 +142,51 @@ class RequestClient:
             return res
 
         try:
-            tokens = await self.client.lget(request_id)
+            request_hash = await self.get_request_id_hash(request_id)
+            tokens = await self.client.lget(request_hash)
+            assert len(tokens) > 0 # if no tokens are found then retry with the database
             data = {}
             for token in tokens:
-                entry = _decode(await self.client.hgetall(request_id + token))
-                data[entry['date']] = entry
+                pipe = self.client.pipeline()
+                fut1 = self.client.hgetall(request_hash + token)
+                fut2 = self.client.expire(request_hash + token, self.expiration)
+                fut3 = self.client.expire(request_hash, self.expiration)
+                await pipe.execute()
+                res = await asyncio.gather(fut1, fut2, fut3)
+                entry = _decode(res[0])
+                data[entry['date']] = entry # this line validates the results are in the proper format
         except:
-            logger.error(traceback.format_exc())
+            logger.debug('Cache could not determine values. Retrying with database...')
+            try:
+                # collect data from database
+                data = await exec_baked('BY_DATE', **{
+                    'request_id': request_id,
+                    **{key: (await self.client.hgetall(key, key_is_int=True)) for key in ['services', 'statuses', 'sources']}
+                })
+
+                # lazy-load the data back into the cache
+                request_hash = secrets.token_hex(nbytes=16)
+                for entry in data.values():
+                    payload = {'request_id': request_id, **{k: str(v) if v else '' for k, v in entry.items()}}
+                    hextoken = secrets.token_hex(nbytes=16)
+                    pipe = self.client.pipeline()
+                    fut1 = pipe.hmset_dict(request_hash + hextoken, payload)
+                    fut2 = pipe.expire(request_hash + hextoken, self.expiration)
+                    fut3 = pipe.lpush(request_hash, hextoken)
+                    fut4 = pipe.expire(request_hash, self.expiration)
+                    await pipe.execute()
+                    await asyncio.gather(fut1, fut2, fut3, fut4)
+                await self.update_request_id_hash(request_id, request_hash)
+            except:
+                raise
+
+        if postprocess and postprocess in self.POSTPROCESS_FUNCTIONS.keys():
+            try:
+                return self.POSTPROCESS_FUNCTIONS[postprocess](data)
+            except:
+                raise
         else:
-            if postprocess and postprocess in self.POSTPROCESS_FUNCTIONS:
-                try:
-                    res = self.POSTPROCESS_FUNCTIONS[postprocess](data)
-                except:
-                    logger.error(f'Postprocessing of {request_id} data failed with error: {traceback.format_exc()}')
-                else:
-                    return res
-            else:
-                return data
+            return data
 
     async def is_unique(self, request_id, msg):
         data = await self.get(request_id)
@@ -162,12 +206,15 @@ class RequestClient:
         if is_unique:
             data = {k: str(v) if v else '' for k, v in msg.items()}
             try:
+                request_hash = await self.get_request_id_hash(request_id)
+                if not request_hash:
+                    request_hash = await self.set_request_id_hash(request_id)
                 hextoken = secrets.token_hex(nbytes=16)
                 pipe = self.client.pipeline()
-                fut1 = pipe.hmset_dict(request_id + hextoken, data)
-                fut2 = pipe.expire(request_id + hextoken, SECONDS_TO_LIVE)
-                fut3 = pipe.lpush(request_id, hextoken)
-                fut4 = pipe.expire(request_id, SECONDS_TO_LIVE)
+                fut1 = pipe.hmset_dict(request_hash + hextoken, data)
+                fut2 = pipe.expire(request_hash + hextoken, self.expiration)
+                fut3 = pipe.lpush(request_hash, hextoken)
+                fut4 = pipe.expire(request_hash, self.expiration)
                 await pipe.execute()
                 res = await asyncio.gather(fut1, fut2, fut3, fut4)
             except:


### PR DESCRIPTION
Currently we are seeing errors when using Redis to compute metrics. This occurs when cached values are expired before they are accessed for metric computation. In order to avoid these errors, we will first increase the `SECONDS_TO_LIVE` environment variable value. However, in the case that a key still reaches expiration we would like to handle this error by grabbing the data from the database. We can then utilize a lazy-loading caching pattern to re-write this value back to the cache.