### PR TITLE
Add test for mismatched datetimes in metrics

### DIFF
--- a/bakery.py
+++ b/bakery.py
@@ -121,8 +121,6 @@ async def process_statuses_by_date(baked_query, **bound_params):
                 if f'{name}_id' in entry:
                     entry[name] = bound_params[table][entry[f'{name}_id']]
                     del entry[f'{name}_id']
-            # remove the tzinfo from the date value
-            entry['date'] = entry['date'].replace(tzinfo=None)
             statuses_by_date[entry['date']] = entry
     except Exception as err:
         raise err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,11 +143,11 @@ def mock_payload():
         'request_id': uuid.uuid4().hex,
         'inventory_id': uuid.uuid4().hex,
         'system_id': uuid.uuid4().hex,
-        'account': randint(pow(10, 5), pow(10, 6) - 1),
-        'service': ''.join([random.choice(string.ascii_uppercase) for _ in range(6)]),
-        'source': ''.join([random.choice(string.ascii_uppercase) for _ in range(6)]),
-        'status': ''.join([random.choice(string.ascii_uppercase) for _ in range(6)]),
-        'status_msg': ''.join([random.choice(string.ascii_uppercase) for _ in range(6)]),
+        'account': randint(pow(10, 5), pow(10,6) - 1),
+        'service': ''.join([random.choice(string.ascii_lowercase) for _ in range(6)]),
+        'source': ''.join([random.choice(string.ascii_lowercase) for _ in range(6)]),
+        'status': ''.join([random.choice(string.ascii_lowercase) for _ in range(6)]),
+        'status_msg': ''.join([random.choice(string.ascii_lowercase) for _ in range(6)]),
         'date': str(datetime.now(tz=timezone.utc))
     }
 


### PR DESCRIPTION
This PR corrects some of the payload processing logic to parse datetime values before inserting into the cache. Also included in this PR is a test for this functionality.